### PR TITLE
refactor: use experimental decorators for withLogger

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-fire",
-  "version": "4.14.2-beta",
+  "version": "4.14.3-beta",
   "author": "Melle Dijkstra",
   "description": "Google App Script utilities to automate the FIRE google sheet",
   "license": "MIT",

--- a/src/server/import-pipeline/rpc.ts
+++ b/src/server/import-pipeline/rpc.ts
@@ -157,23 +157,28 @@ function buildPreviewRows(
 /**
  * Wraps a pipeline function with standardised error handling and logging.
  */
-function withLogger<T>(
-  name: string,
-  fn: () => T,
-): T | ErrorServerResponse {
-  try {
-    Logger.time(name)
-    const result = fn()
-    Logger.timeEnd(name)
-    return result
-  }
-  catch (error) {
-    Logger.error(error)
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : String(error),
+function withLogger(
+  _target: unknown,
+  propertyKey: string,
+  descriptor: PropertyDescriptor,
+) {
+  const originalMethod = descriptor.value
+  descriptor.value = function (this: unknown, ...args: unknown[]) {
+    try {
+      Logger.time(propertyKey)
+      const result = originalMethod.apply(this, args)
+      Logger.timeEnd(propertyKey)
+      return result
+    }
+    catch (error) {
+      Logger.error(error)
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      } as ErrorServerResponse
     }
   }
+  return descriptor
 }
 
 /**
@@ -220,12 +225,13 @@ function processImportData(inputTable: RawTable, accountConfig: Config): FireTab
  * @param {string} bankAccount - The bank account identifier which is used to lookup configuration
  * @returns {ServerResponse} A response object which contains a message to be displayed to the user
  */
-export function importPipeline(
-  inputTable: RawTable,
-  bankAccount: string,
-  userDecisions?: Record<string, TransactionAction>,
-): ServerResponse {
-  return withLogger('importPipeline', () => {
+class PipelineRPC {
+  @withLogger
+  static importPipeline(
+    inputTable: RawTable,
+    bankAccount: string,
+    userDecisions?: Record<string, TransactionAction>,
+  ): ServerResponse {
     const fireSheet = new FireSheet()
     const accountConfig = Config.getAccountConfiguration(bankAccount)
     const _userDecisions = userDecisions ? new Map(Object.entries(userDecisions)) : undefined
@@ -259,14 +265,13 @@ export function importPipeline(
     Logger.log(msg)
 
     return { success: true, message: msg }
-  })
-}
+  }
 
-export function previewPipeline(
-  table: RawTable,
-  bankAccount: string,
-): ServerResponse<ImportPreviewReport> {
-  return withLogger('previewPipeline', () => {
+  @withLogger
+  static previewPipeline(
+    table: RawTable,
+    bankAccount: string,
+  ): ServerResponse<ImportPreviewReport> {
     const config = Config.getAccountConfiguration(bankAccount)
     const previewTable = processImportData(table, config)
 
@@ -302,5 +307,8 @@ export function previewPipeline(
         },
       },
     }
-  })
+  }
 }
+
+export const importPipeline = PipelineRPC.importPipeline.bind(PipelineRPC)
+export const previewPipeline = PipelineRPC.previewPipeline.bind(PipelineRPC)

--- a/src/server/import-pipeline/rpc.ts
+++ b/src/server/import-pipeline/rpc.ts
@@ -1,4 +1,4 @@
-import type { ServerResponse, RawTable, ImportPreviewReport, UserDecisions, TransactionAction, TransactionStatus, TransactionMeta, ErrorServerResponse } from '@/common/types'
+import type { ServerResponse, RawTable, ImportPreviewReport, UserDecisions, TransactionAction, TransactionStatus, TransactionMeta } from '@/common/types'
 import { Config } from '../config'
 import { FireTable, FireSheet, type CellValue } from '../table'
 import { Table } from '../table/Table'
@@ -161,13 +161,12 @@ function withLogger(
   _target: unknown,
   propertyKey: string,
   descriptor: PropertyDescriptor,
-) {
+): PropertyDescriptor {
   const originalMethod = descriptor.value
   descriptor.value = function (this: unknown, ...args: unknown[]) {
     try {
       Logger.time(propertyKey)
       const result = originalMethod.apply(this, args)
-      Logger.timeEnd(propertyKey)
       return result
     }
     catch (error) {
@@ -175,7 +174,10 @@ function withLogger(
       return {
         success: false,
         error: error instanceof Error ? error.message : String(error),
-      } as ErrorServerResponse
+      }
+    }
+    finally {
+      Logger.timeEnd(propertyKey)
     }
   }
   return descriptor
@@ -215,17 +217,17 @@ function processImportData(inputTable: RawTable, accountConfig: Config): FireTab
   }).sortByDate()
 }
 
-/**
- * Handles incoming CSV (already parsed by the frontend) and processes it in order to be imported
- * into the spreadsheet.
- *
- * It uses configuration from the user to determine how the CSV should be processed.
- *
- * @param {RawTable} inputTable - The table object which contains the CSV data
- * @param {string} bankAccount - The bank account identifier which is used to lookup configuration
- * @returns {ServerResponse} A response object which contains a message to be displayed to the user
- */
 class PipelineRPC {
+  /**
+   * Handles incoming CSV (already parsed by the frontend) and processes it in order to be imported
+   * into the spreadsheet.
+   *
+   * It uses configuration from the user to determine how the CSV should be processed.
+   *
+   * @param {RawTable} inputTable - The table object which contains the CSV data
+   * @param {string} bankAccount - The bank account identifier which is used to lookup configuration
+   * @returns {ServerResponse} A response object which contains a message to be displayed to the user
+   */
   @withLogger
   static importPipeline(
     inputTable: RawTable,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "experimentalDecorators": true,
     // because we use vite compiler we don't let TS emit any files
     // we just want to use it as a type checker
     "noEmit": true,


### PR DESCRIPTION
Resolves the issue to change `withLogger` higher-order function into a decorator instead in `src/server/import-pipeline/rpc.ts`.

It enables `experimentalDecorators` in `tsconfig.json` to be able to compile successfully in the test-runner. It creates a `PipelineRPC` class as a container, applying the decorator to static methods, and binding them upon export so that their use remains perfectly compatible for Google Apps Script without changing the public interface.

---
*PR created automatically by Jules for task [14381794457925781148](https://jules.google.com/task/14381794457925781148) started by @melledijkstra*