### PR TITLE
Feature: Add rule-based import pipeline for transaction processing (generated by claude)

### DIFF
--- a/src/client/components/PreviewReportSummary.svelte
+++ b/src/client/components/PreviewReportSummary.svelte
@@ -13,6 +13,9 @@
   <Badge color="green" border>Valid Rows: {report.summary.validCount}</Badge>
   <Badge color="red" border>Removed Rows: {report.summary.removedCount}</Badge>
   <Badge color="yellow" border>Duplicate Rows: {report.summary.duplicateCount}</Badge>
+  {#if report.summary.rulesLoaded > 0}
+    <Badge color="blue" border>Rules Applied: {report.summary.rulesApplied} of {report.summary.rulesLoaded}</Badge>
+  {/if}
   {#if report.newBalance !== undefined}
     <p>New Balance: <strong>{report.newBalance.toLocaleString(locale, { style: 'currency', currency: 'EUR' })}</strong></p>
   {/if}

--- a/src/client/components/PreviewTable.svelte
+++ b/src/client/components/PreviewTable.svelte
@@ -14,6 +14,7 @@
 
   const headers = Array.from(FIRE_COLUMNS);
   const hasDetectedDuplicates = $derived(report.summary.duplicateCount > 0);
+  const hasActionColumn = $derived(hasDetectedDuplicates || report.summary.removedCount > 0);
 
   const getRowClass = (status: TransactionStatus): string => {
     if (status === 'removed') return 'bg-red-100! dark:bg-red-900! line-through';
@@ -24,7 +25,7 @@
 
 <FlowTable class={[tableClass, 'border border-gray-400 mb-2.5 mr-2.5']} striped hoverable>
   <TableHead>
-    {#if hasDetectedDuplicates}
+    {#if hasActionColumn}
       <TableHeadCell class="py-2 px-1 normal-case">Action</TableHeadCell>
     {/if}
     {#each headers as header, i (i)}
@@ -35,8 +36,9 @@
     {#each report.rows as row, i (`${report.hashes[i]}-${i}`)}
       {@const hash = report.hashes[i]}
       {@const meta = report.transactionMeta[hash]}
+      {@const rowRuleInfo = report.ruleInfo?.[hash]}
       <TableBodyRow class={getRowClass(meta.status)}>
-        {#if hasDetectedDuplicates}
+        {#if hasActionColumn}
           <TableBodyCell class="py-2 px-1 text-xs text-center">
             {#if meta.status === 'duplicate'}
               <Select
@@ -54,7 +56,12 @@
                 <option value="import">Import</option>
               </Select>
             {:else if meta.status === 'removed'}
-              <span class="text-gray-500">Removed</span>
+              <span
+                class="text-gray-500"
+                title={rowRuleInfo?.excludedByRule ? `Excluded by rule: ${rowRuleInfo.excludedByRule}` : undefined}
+              >
+                Excluded
+              </span>
             {:else}
               <span class="text-green-600">Import</span>
             {/if}

--- a/src/client/import-dialog/ImportStep.svelte
+++ b/src/client/import-dialog/ImportStep.svelte
@@ -25,8 +25,7 @@
       .then((response) => {
         if (response.success) {
           importFinished = true;
-          message = response.message ?? "Import successful! This dialog will close shortly.";
-          setTimeout(google.script.host.close, 3000);
+          message = response.message ?? "Import successful!";
         } else {
           onFailure(response);
         }
@@ -70,5 +69,6 @@
     </Button>
   {:else}
     <BadgeCheckSolid class="w-40 h-40" color="green" />
+    <Button color="light" onclick={() => google.script.host.close()}>Close</Button>
   {/if}
 </div>

--- a/src/client/import-dialog/PreviewStep.svelte
+++ b/src/client/import-dialog/PreviewStep.svelte
@@ -4,8 +4,8 @@
   import PreviewTable from "../components/PreviewTable.svelte";
   import { excludeRowsFromData } from "../utils/importing";
   import { importState } from "../states/import.svelte";
-  import { Alert, Button, Spinner } from "flowbite-svelte";
-  import { InfoCircleSolid } from "flowbite-svelte-icons";
+  import { Accordion, AccordionItem, Alert, Button, Spinner } from "flowbite-svelte";
+  import { ExclamationCircleSolid, InfoCircleSolid } from "flowbite-svelte-icons";
   import PreviewReportSummary from "../components/PreviewReportSummary.svelte";
 
   const onPreviewSuccess = (
@@ -72,5 +72,26 @@
 
 {#if importState.previewReport}
   <PreviewReportSummary report={importState.previewReport} />
+
+  {#if importState.previewReport.ruleWarnings?.length}
+    <Accordion class="mb-2">
+      <AccordionItem>
+        {#snippet header()}
+          <span class="flex items-center gap-2 text-yellow-600 dark:text-yellow-400">
+            <ExclamationCircleSolid class="w-4 h-4" />
+            Rule Warnings ({importState.previewReport.ruleWarnings.length})
+          </span>
+        {/snippet}
+        <ul class="list-disc pl-4 text-sm">
+          {#each importState.previewReport.ruleWarnings as warning}
+            <li>
+              <strong>{warning.ruleName}</strong> (row {warning.rowIndex}): {warning.message}
+            </li>
+          {/each}
+        </ul>
+      </AccordionItem>
+    </Accordion>
+  {/if}
+
   <PreviewTable report={importState.previewReport} />
 {/if}

--- a/src/client/utils/__mocks__/serverFunctions.ts
+++ b/src/client/utils/__mocks__/serverFunctions.ts
@@ -82,6 +82,7 @@ class ServerFunctions implements PromisifiedServerFunctionsInterface {
           duplicateCount,
           removedCount,
           rulesApplied: 3,
+          rulesLoaded: 5,
           totalRows: rows.length,
           validCount,
         },

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -35,6 +35,17 @@ export interface TransactionMeta {
   action: TransactionAction
 }
 
+export interface RuleWarningInfo {
+  ruleName: string
+  rowIndex: number
+  message: string
+}
+
+export interface RowRuleInfo {
+  excludedByRule?: string
+  modifications?: Record<string, string>
+}
+
 export interface ImportPreviewReport {
   /** Formatted transaction rows in the same order as `hashes`. Always aligned to FIRE_COLUMNS. */
   rows: string[][]
@@ -49,7 +60,12 @@ export interface ImportPreviewReport {
     removedCount: number
     duplicateCount: number
     rulesApplied: number
+    rulesLoaded: number
   }
+  /** Per-hash rule info for UI tooltips, keyed by row hash. */
+  ruleInfo?: Record<string, RowRuleInfo>
+  /** Warnings from rule loading/processing for display in UI. */
+  ruleWarnings?: RuleWarningInfo[]
 }
 
 export type UserDecisions = Map<string, TransactionAction>

--- a/src/server/import-pipeline/rpc.test.ts
+++ b/src/server/import-pipeline/rpc.test.ts
@@ -19,6 +19,18 @@ import { fakeTestBankImportData } from '@/fixtures/test-bank'
 import { removeFilterCriteria } from '../spreadsheet/spreadsheet'
 import { FireSheet } from '../spreadsheet/FireSheet'
 import { slugify } from '@/common/helpers'
+import { loadImportRules } from '../rule-engine'
+import type { ImportRule } from '../rule-engine'
+
+vi.mock('../rule-engine', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../rule-engine')>()
+  return {
+    ...actual,
+    loadImportRules: vi.fn(() => ({ rules: [], warnings: [] })),
+  }
+})
+
+const loadImportRulesMock = vi.mocked(loadImportRules)
 
 vi.mock('../globals', () => ({
   FireSpreadsheet: SpreadsheetMock,
@@ -237,6 +249,237 @@ describe('RPC: Import Functions', () => {
         expect.arrayContaining([new Date(2015, 4, 21), 58.3]),
         expect.arrayContaining([new Date(2015, 4, 20), 20]),
       ])
+    })
+  })
+
+  describe('rule engine integration', () => {
+    const testBankConfig = new Config({
+      accountId: BANK_ID,
+      columnMap: {
+        amount: 'TransactionAmount',
+        date: 'TransactionDate',
+        description: 'Description',
+      },
+    })
+
+    const testData: RawTable = [
+      ['TransactionAmount', 'TransactionDate', 'Description'],
+      ['50', '2024-01-15', 'Grocery Store'],
+      ['-100', '2024-01-16', 'Internal Transfer'],
+      ['30', '2024-01-17', 'Coffee Shop'],
+    ]
+
+    beforeAll(() => {
+      Logger.disable()
+    })
+
+    beforeEach(() => {
+      configSpy.mockReturnValue(testBankConfig)
+    })
+
+    describe('previewPipeline with rules', () => {
+      let getBalanceSpy: ReturnType<typeof vi.spyOn>
+      let fireSheetSpy: ReturnType<typeof vi.spyOn>
+
+      beforeEach(() => {
+        getBalanceSpy = vi.spyOn(AccountUtils, 'getBalance').mockReturnValue(1000)
+        fireSheetSpy = vi.spyOn(FireSheet.prototype, 'getLastImportedTransactions').mockReturnValue(new FireTable([]))
+      })
+
+      afterEach(() => {
+        getBalanceSpy.mockRestore()
+        fireSheetSpy.mockRestore()
+      })
+
+      test('excluded rows appear with removed status', () => {
+        const excludeRule: ImportRule = {
+          ruleName: 'Exclude Internal',
+          banks: ['all'],
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'Internal',
+          action: 'EXCLUDE',
+          actionColumn: 'description',
+          stopProcessing: true,
+          rulePhase: 'POST_TRANSFORM',
+          rowIndex: 2,
+        }
+        loadImportRulesMock.mockReturnValue({ rules: [excludeRule], warnings: [] })
+
+        const response = previewPipeline(structuredClone(testData), BANK_ID)
+
+        expect(response.success).toBe(true)
+        if (response.success && response.data) {
+          expect(response.data.summary.removedCount).toBe(1)
+          expect(response.data.summary.validCount).toBe(2)
+          expect(response.data.summary.rulesApplied).toBe(1)
+          expect(response.data.summary.rulesLoaded).toBe(1)
+
+          // Find the excluded row by checking transactionMeta
+          const removedHashes = Object.entries(response.data.transactionMeta)
+            .filter(([_, meta]) => meta.status === 'removed')
+            .map(([hash]) => hash)
+          expect(removedHashes).toHaveLength(1)
+
+          // ruleInfo should contain the exclusion details
+          expect(response.data.ruleInfo).toBeDefined()
+          const info = response.data.ruleInfo![removedHashes[0]]
+          expect(info.excludedByRule).toBe('Exclude Internal')
+        }
+      })
+
+      test('rule warnings are included in report', () => {
+        loadImportRulesMock.mockReturnValue({
+          rules: [],
+          warnings: [{ ruleName: 'Bad Rule', rowIndex: 3, message: 'Invalid condition' }],
+        })
+
+        const response = previewPipeline(structuredClone(testData), BANK_ID)
+
+        expect(response.success).toBe(true)
+        if (response.success && response.data) {
+          expect(response.data.ruleWarnings).toHaveLength(1)
+          expect(response.data.ruleWarnings![0].ruleName).toBe('Bad Rule')
+        }
+      })
+
+      test('excluded rows do not count toward new balance', () => {
+        getBalanceSpy.mockReturnValue(1000)
+        const excludeRule: ImportRule = {
+          ruleName: 'Exclude Internal',
+          banks: ['all'],
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'Internal',
+          action: 'EXCLUDE',
+          actionColumn: 'description',
+          stopProcessing: true,
+          rulePhase: 'POST_TRANSFORM',
+          rowIndex: 2,
+        }
+        loadImportRulesMock.mockReturnValue({ rules: [excludeRule], warnings: [] })
+
+        const response = previewPipeline(structuredClone(testData), BANK_ID)
+
+        if (response.success && response.data) {
+          // Only Grocery Store (50) and Coffee Shop (30) should count = 80
+          // -100 Internal Transfer is excluded
+          expect(response.data.newBalance).toBeCloseTo(1080, 0)
+        }
+      })
+    })
+
+    describe('importPipeline with rules', () => {
+      let fireSheetSpy: ReturnType<typeof vi.spyOn>
+
+      beforeEach(() => {
+        fireSheetSpy = vi.spyOn(FireSheet.prototype, 'getLastImportedTransactions').mockReturnValue(new FireTable([]))
+      })
+
+      afterEach(() => {
+        fireSheetSpy.mockRestore()
+      })
+
+      test('excluded rows are not imported', () => {
+        const excludeRule: ImportRule = {
+          ruleName: 'Exclude Internal',
+          banks: ['all'],
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'Internal',
+          action: 'EXCLUDE',
+          actionColumn: 'description',
+          stopProcessing: true,
+          rulePhase: 'POST_TRANSFORM',
+          rowIndex: 2,
+        }
+        loadImportRulesMock.mockReturnValue({ rules: [excludeRule], warnings: [] })
+
+        const result = importPipeline(structuredClone(testData), BANK_ID)
+
+        expect(result.success).toBe(true)
+        expect(importDataSpy).toHaveBeenCalled()
+        const [fireTable] = importDataSpy.mock.calls[importDataSpy.mock.calls.length - 1]
+        // Should only have 2 rows (Grocery Store + Coffee Shop)
+        expect(fireTable.getRowCount()).toBe(2)
+        // The Internal Transfer row should not be present
+        const descriptions = fireTable.getFireColumn('description')
+        expect(descriptions).not.toContainEqual('Internal Transfer')
+      })
+
+      test('SET rules modify data before import', () => {
+        const setRule: ImportRule = {
+          ruleName: 'Categorize Coffee',
+          banks: ['all'],
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'Coffee',
+          action: 'SET',
+          actionColumn: 'category',
+          actionValue: 'Eating Out',
+          stopProcessing: false,
+          rulePhase: 'POST_TRANSFORM',
+          rowIndex: 2,
+        }
+        loadImportRulesMock.mockReturnValue({ rules: [setRule], warnings: [] })
+
+        const result = importPipeline(structuredClone(testData), BANK_ID)
+
+        expect(result.success).toBe(true)
+        expect(importDataSpy).toHaveBeenCalled()
+        const [fireTable] = importDataSpy.mock.calls[importDataSpy.mock.calls.length - 1]
+        const categories = fireTable.getFireColumn('category')
+        // One of the rows should have 'Eating Out' category
+        expect(categories).toContainEqual('Eating Out')
+      })
+
+      test('PRE_TRANSFORM rules run on raw CSV column names', () => {
+        const preRule: ImportRule = {
+          ruleName: 'Exclude by raw column',
+          banks: ['all'],
+          conditionColumn: 'Description',
+          condition: 'CONTAINS',
+          conditionValue: 'Internal',
+          action: 'EXCLUDE',
+          actionColumn: 'Description',
+          stopProcessing: true,
+          rulePhase: 'PRE_TRANSFORM',
+          rowIndex: 2,
+        }
+        loadImportRulesMock.mockReturnValue({ rules: [preRule], warnings: [] })
+
+        const result = importPipeline(structuredClone(testData), BANK_ID)
+
+        expect(result.success).toBe(true)
+        expect(importDataSpy).toHaveBeenCalled()
+        const [fireTable] = importDataSpy.mock.calls[importDataSpy.mock.calls.length - 1]
+        expect(fireTable.getRowCount()).toBe(2)
+      })
+
+      test('import message includes rule stats', () => {
+        const excludeRule: ImportRule = {
+          ruleName: 'Exclude Internal',
+          banks: ['all'],
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'Internal',
+          action: 'EXCLUDE',
+          actionColumn: 'description',
+          stopProcessing: true,
+          rulePhase: 'POST_TRANSFORM',
+          rowIndex: 2,
+        }
+        loadImportRulesMock.mockReturnValue({ rules: [excludeRule], warnings: [] })
+
+        const result = importPipeline(structuredClone(testData), BANK_ID)
+
+        expect(result.success).toBe(true)
+        if (result.success) {
+          expect(result.message).toContain('imported 2 rows!')
+          expect(result.message).toContain('1 rule(s) applied')
+          expect(result.message).toContain('1 row(s) excluded by rules')
+        }
+      })
     })
   })
 })

--- a/src/server/import-pipeline/rpc.ts
+++ b/src/server/import-pipeline/rpc.ts
@@ -6,6 +6,7 @@ import type {
   TransactionAction,
   TransactionStatus,
   TransactionMeta,
+  RowRuleInfo,
 } from '@/common/types'
 import { Config } from '../config'
 import { FireTable } from '../table/FireTable'
@@ -18,6 +19,15 @@ import { Logger } from '@/common/logger'
 import { removeFilterCriteria } from '../spreadsheet/spreadsheet'
 import { FEATURES } from '@/common/settings'
 import { getRowHash } from '../deduplication/duplicate-finder'
+import {
+  loadImportRules,
+  getRulesForBank,
+  getRulesForPhase,
+  processRules,
+  createRawColumnResolver,
+  createFireColumnResolver,
+} from '../rule-engine'
+import type { RuleProcessingResult, RowRuleResult } from '../rule-engine'
 
 /**
  * Loads hashes of already-imported transactions from the sheet for duplicate detection.
@@ -106,45 +116,84 @@ interface PreviewRowsResult {
   rows: string[][]
   hashes: string[]
   transactionMeta: Record<string, TransactionMeta>
+  ruleInfo: Record<string, RowRuleInfo>
   validAmounts: number[]
   duplicateCount: number
   validCount: number
+  removedCount: number
+}
+
+/** Classifies a row's status based on rule results and existing hashes. */
+function classifyRow(
+  hash: string,
+  rowResult: RowRuleResult | undefined,
+  existingHashes: Set<string>,
+): TransactionStatus {
+  if (rowResult?.excluded) return 'removed'
+  if (existingHashes.has(hash)) return 'duplicate'
+  return 'valid'
+}
+
+/** Collects rule info for a single row (exclusion or modification details). */
+function collectRowRuleInfo(
+  hash: string,
+  rowResult: RowRuleResult | undefined,
+  ruleInfo: Record<string, RowRuleInfo>,
+): void {
+  if (!rowResult) return
+
+  if (rowResult.excluded && rowResult.excludedByRule) {
+    ruleInfo[hash] = { excludedByRule: rowResult.excludedByRule }
+    return
+  }
+
+  if (rowResult.matchedRules.length > 0 && !rowResult.excluded) {
+    const modifications: Record<string, string> = {}
+    for (const [col, val] of Object.entries(rowResult.modifications)) {
+      modifications[col] = String(val ?? '')
+    }
+    if (Object.keys(modifications).length > 0) {
+      ruleInfo[hash] = { ...ruleInfo[hash], modifications }
+    }
+  }
 }
 
 /**
- * Classifies each transaction row as valid or duplicate, formats the
- * row for display, and collects the numeric amounts for valid rows.
+ * Classifies each transaction row as valid, duplicate, or removed (by rule),
+ * formats the row for display, and collects the numeric amounts for valid rows.
  */
 function buildPreviewRows(
   previewTable: FireTable,
   existingHashes: Set<string>,
   autoFillColumns: number[],
+  rowRuleResults?: RowRuleResult[],
 ): PreviewRowsResult {
   const rows: string[][] = []
   const hashes: string[] = []
   const transactionMeta: Record<string, TransactionMeta> = {}
+  const ruleInfo: Record<string, RowRuleInfo> = {}
   const validAmounts: number[] = []
   const amountColIndex = FireTable.getFireColumnIndex('amount')
   let duplicateCount = 0
   let validCount = 0
+  let removedCount = 0
 
-  for (const row of previewTable.getData()) {
+  const data = previewTable.getData()
+  for (let i = 0; i < data.length; i++) {
+    const row = data[i]
     const hash = getRowHash(row)
-    let status: TransactionStatus
-    const action: TransactionAction = 'import'
+    const rowResult = rowRuleResults?.[i]
+    const status = classifyRow(hash, rowResult, existingHashes)
 
-    if (existingHashes.has(hash)) {
-      status = 'duplicate'
-      duplicateCount++
-    }
+    if (status === 'removed') removedCount++
+    else if (status === 'duplicate') duplicateCount++
     else {
-      status = 'valid'
       validCount++
       const amount = row[amountColIndex]
-      if (isNumeric(amount)) {
-        validAmounts.push(Number(amount))
-      }
+      if (isNumeric(amount)) validAmounts.push(Number(amount))
     }
+
+    collectRowRuleInfo(hash, rowResult, ruleInfo)
 
     const formattedRow = [...row]
     for (const colIndex of autoFillColumns) {
@@ -158,10 +207,10 @@ function buildPreviewRows(
 
     hashes.push(hash)
     rows.push(formattedRow.map(formatCellValue))
-    transactionMeta[hash] = { status, action }
+    transactionMeta[hash] = { status, action: 'import' }
   }
 
-  return { rows, hashes, transactionMeta, validAmounts, duplicateCount, validCount }
+  return { rows, hashes, transactionMeta, ruleInfo, validAmounts, duplicateCount, validCount, removedCount }
 }
 
 /**
@@ -193,15 +242,76 @@ function withLogger(
   return descriptor
 }
 
+/** Return type for processImportData, includes rule processing results. */
+interface ProcessImportDataResult {
+  fireTable: FireTable
+  ruleResult: RuleProcessingResult
+}
+
+/** Creates an empty RuleProcessingResult with the given rule count. */
+function emptyRuleResult(rulesLoaded: number, warnings: RuleProcessingResult['warnings'] = []): RuleProcessingResult {
+  return {
+    rowResults: [],
+    rulesLoaded,
+    rulesApplied: 0,
+    rowsExcluded: 0,
+    rowsModified: 0,
+    warnings: [...warnings],
+  }
+}
+
+/**
+ * Merges two RuleProcessingResults.
+ * Row results from the second are appended if the first has none;
+ * otherwise they are merged per-index (for two-phase processing on the same row set).
+ */
+function mergeRuleResults(a: RuleProcessingResult, b: RuleProcessingResult): RuleProcessingResult {
+  let mergedRowResults: RowRuleResult[]
+
+  if (a.rowResults.length === 0) {
+    mergedRowResults = b.rowResults
+  }
+  else if (b.rowResults.length === 0) {
+    mergedRowResults = a.rowResults
+  }
+  else {
+    // Merge per-index: a row excluded by either phase stays excluded
+    mergedRowResults = a.rowResults.map((aRow, i) => {
+      const bRow = b.rowResults[i]
+      if (!bRow) return aRow
+      return {
+        excluded: aRow.excluded || bRow.excluded,
+        excludedByRule: aRow.excludedByRule ?? bRow.excludedByRule,
+        matchedRules: [...aRow.matchedRules, ...bRow.matchedRules],
+        modifications: { ...aRow.modifications, ...bRow.modifications },
+      }
+    })
+  }
+
+  return {
+    rowResults: mergedRowResults,
+    rulesLoaded: a.rulesLoaded,
+    rulesApplied: a.rulesApplied + b.rulesApplied,
+    rowsExcluded: mergedRowResults.filter(r => r.excluded).length,
+    rowsModified: mergedRowResults.filter(r => !r.excluded && Object.keys(r.modifications).length > 0).length,
+    warnings: [...a.warnings, ...b.warnings],
+  }
+}
+
 /**
  * Processes raw input data into the structured Firesheet format,
- * applying filtering and sorting rules.
+ * applying import rules, filtering, and sorting.
  *
- * @param {RawTable} inputTable - The raw input data
- * @param {Config} accountConfig - The configuration for the account
- * @returns {FireTable} The processed data, ready for import
+ * @param inputTable - The raw input data
+ * @param accountConfig - The configuration for the account
+ * @param dryRun - If true, rules track results without mutating (for preview)
+ * @returns The processed FireTable and rule processing results
  */
-function processImportData(inputTable: RawTable, accountConfig: Config): FireTable {
+function processImportData(
+  inputTable: RawTable,
+  accountConfig: Config,
+  dryRun: boolean = false,
+): ProcessImportDataResult {
   const cloned = structuredClone(inputTable)
   const rawTable = new Table(cloned)
 
@@ -212,19 +322,69 @@ function processImportData(inputTable: RawTable, accountConfig: Config): FireTab
     throw new Error('No header row detected in import data!')
   }
 
+  // Load rules
+  const { rules, warnings: loadWarnings } = loadImportRules()
+  const bankRules = getRulesForBank(rules, accountConfig.getAccountId())
+  let combinedResult = emptyRuleResult(rules.length, loadWarnings)
+
   //
-  // BEFORE IMPORT RULES
+  // BEFORE IMPORT RULES (PRE_TRANSFORM phase)
   //
   rawTable.removeEmptyRows()
 
+  const preRules = getRulesForPhase(bankRules, 'PRE_TRANSFORM')
+  if (preRules.length > 0) {
+    const preResult = processRules(
+      rawTable,
+      preRules,
+      createRawColumnResolver(headerRow),
+      dryRun,
+    )
+    combinedResult = mergeRuleResults(combinedResult, preResult)
+
+    if (!dryRun) {
+      const excludedIndices = preResult.rowResults
+        .map((r, i) => r.excluded ? i : -1)
+        .filter(i => i !== -1)
+      if (excludedIndices.length > 0) {
+        rawTable.deleteRows(excludedIndices)
+      }
+    }
+  }
+
   //
-  // IMPORT RULES
+  // IMPORT RULES (transform step)
   //
-  return FireTable.fromCSV({
+  const fireTable = FireTable.fromCSV({
     headers: headerRow,
     rows: rawTable.getData(),
     config: accountConfig,
-  }).sortByDate()
+  })
+
+  // POST_TRANSFORM phase
+  const postRules = getRulesForPhase(bankRules, 'POST_TRANSFORM')
+  if (postRules.length > 0) {
+    const postResult = processRules(
+      fireTable,
+      postRules,
+      createFireColumnResolver(),
+      dryRun,
+    )
+    combinedResult = mergeRuleResults(combinedResult, postResult)
+
+    if (!dryRun) {
+      const excludedIndices = postResult.rowResults
+        .map((r, i) => r.excluded ? i : -1)
+        .filter(i => i !== -1)
+      if (excludedIndices.length > 0) {
+        fireTable.deleteRows(excludedIndices)
+      }
+    }
+  }
+
+  fireTable.sortByDate()
+
+  return { fireTable, ruleResult: combinedResult }
 }
 
 class PipelineRPC {
@@ -252,7 +412,7 @@ class PipelineRPC {
 
     prepareSheetForImport(fireSheet)
 
-    const fireTable = processImportData(inputTable, accountConfig)
+    const { fireTable, ruleResult } = processImportData(inputTable, accountConfig, false)
 
     if (fireTable.isEmpty()) {
       const msg = 'No rows to import, check your import data or configuration!'
@@ -273,7 +433,14 @@ class PipelineRPC {
     fireSheet.importData(finalTable, autoFillColumns)
     Logger.timeEnd('FireSheet.importData')
 
-    const msg = `imported ${finalTable.getRowCount()} rows!`
+    const parts = [`imported ${finalTable.getRowCount()} rows!`]
+    if (ruleResult.rulesApplied > 0) {
+      parts.push(`${ruleResult.rulesApplied} rule(s) applied`)
+    }
+    if (ruleResult.rowsExcluded > 0) {
+      parts.push(`${ruleResult.rowsExcluded} row(s) excluded by rules`)
+    }
+    const msg = parts.join(' — ')
     Logger.log(msg)
 
     return { success: true, message: msg }
@@ -285,7 +452,7 @@ class PipelineRPC {
     bankAccount: string,
   ): ServerResponse<ImportPreviewReport> {
     const config = Config.getAccountConfiguration(bankAccount)
-    const previewTable = processImportData(table, config)
+    const { fireTable: previewTable, ruleResult } = processImportData(table, config, true)
 
     let existingHashes: Set<string> = new Set()
 
@@ -297,8 +464,8 @@ class PipelineRPC {
     }
 
     const autoFillColumns = config.autoFillEnabled ? config.autoFillColumnIndices : []
-    const { rows, hashes, transactionMeta, validAmounts, duplicateCount, validCount }
-      = buildPreviewRows(previewTable, existingHashes, autoFillColumns)
+    const { rows, hashes, transactionMeta, ruleInfo, validAmounts, duplicateCount, validCount, removedCount }
+      = buildPreviewRows(previewTable, existingHashes, autoFillColumns, ruleResult.rowResults)
 
     const newBalance = AccountUtils.calculateNewBalance(bankAccount, validAmounts)
 
@@ -313,10 +480,14 @@ class PipelineRPC {
           totalRows: previewTable.getRowCount(),
           validCount,
           duplicateCount,
-          // PENDING IMPLEMENTATION
-          removedCount: 0,
-          rulesApplied: 0,
+          removedCount,
+          rulesApplied: ruleResult.rulesApplied,
+          rulesLoaded: ruleResult.rulesLoaded,
         },
+        ruleInfo: Object.keys(ruleInfo).length > 0 ? ruleInfo : undefined,
+        ruleWarnings: ruleResult.warnings.length > 0
+          ? ruleResult.warnings.map(w => ({ ruleName: w.ruleName, rowIndex: w.rowIndex, message: w.message }))
+          : undefined,
       },
     }
   }

--- a/src/server/rule-engine/actions.test.ts
+++ b/src/server/rule-engine/actions.test.ts
@@ -1,0 +1,77 @@
+import { applyAction } from './actions'
+
+describe('applyAction', () => {
+  describe('EXCLUDE', () => {
+    test('returns current value unchanged', () => {
+      expect(applyAction('hello', 'EXCLUDE')).toBe('hello')
+    })
+
+    test('returns null unchanged', () => {
+      expect(applyAction(null, 'EXCLUDE')).toBe(null)
+    })
+  })
+
+  describe('SET', () => {
+    test('returns the action value', () => {
+      expect(applyAction('old', 'SET', 'new')).toBe('new')
+    })
+
+    test('returns null when action value is undefined', () => {
+      expect(applyAction('old', 'SET')).toBe(null)
+    })
+
+    test('overwrites numeric value with string', () => {
+      expect(applyAction(42, 'SET', 'Groceries')).toBe('Groceries')
+    })
+  })
+
+  describe('ADD', () => {
+    test('adds numeric action value to current value', () => {
+      expect(applyAction(100, 'ADD', '50')).toBe(150)
+    })
+
+    test('handles null current value as 0', () => {
+      expect(applyAction(null, 'ADD', '50')).toBe(50)
+    })
+
+    test('returns current value when action value is non-numeric', () => {
+      expect(applyAction(100, 'ADD', 'abc')).toBe(100)
+    })
+
+    test('returns current value when cell value is non-numeric', () => {
+      expect(applyAction('abc', 'ADD', '50')).toBe('abc')
+    })
+
+    test('handles negative action value', () => {
+      expect(applyAction(100, 'ADD', '-30')).toBe(70)
+    })
+
+    test('handles decimal values', () => {
+      expect(applyAction(10.5, 'ADD', '2.3')).toBeCloseTo(12.8)
+    })
+  })
+
+  describe('SUBTRACT', () => {
+    test('subtracts numeric action value from current value', () => {
+      expect(applyAction(100, 'SUBTRACT', '30')).toBe(70)
+    })
+
+    test('handles null current value as 0', () => {
+      expect(applyAction(null, 'SUBTRACT', '50')).toBe(-50)
+    })
+
+    test('returns current value when action value is non-numeric', () => {
+      expect(applyAction(100, 'SUBTRACT', 'abc')).toBe(100)
+    })
+
+    test('handles string number as current value', () => {
+      expect(applyAction('100', 'SUBTRACT', '30')).toBe(70)
+    })
+  })
+
+  describe('edge cases', () => {
+    test('returns current value for unknown action', () => {
+      expect(applyAction('test', 'UNKNOWN' as never, 'value')).toBe('test')
+    })
+  })
+})

--- a/src/server/rule-engine/actions.ts
+++ b/src/server/rule-engine/actions.ts
@@ -1,0 +1,44 @@
+import type { CellValue } from '../table/types'
+import type { RuleAction } from './types'
+
+/**
+ * Applies a rule action to a cell value.
+ *
+ * For EXCLUDE, the caller is responsible for marking the row as excluded;
+ * this function returns the current value unchanged.
+ *
+ * @param currentValue - The current cell value
+ * @param action - The action to apply
+ * @param actionValue - The value to use for the action
+ * @returns The new cell value after applying the action
+ */
+export function applyAction(
+  currentValue: CellValue,
+  action: RuleAction,
+  actionValue?: string,
+): CellValue {
+  switch (action) {
+    case 'EXCLUDE':
+      return currentValue
+
+    case 'SET':
+      return actionValue ?? null
+
+    case 'ADD': {
+      const current = Number(currentValue ?? 0)
+      const addend = Number(actionValue)
+      if (Number.isNaN(current) || Number.isNaN(addend)) return currentValue
+      return current + addend
+    }
+
+    case 'SUBTRACT': {
+      const current = Number(currentValue ?? 0)
+      const subtrahend = Number(actionValue)
+      if (Number.isNaN(current) || Number.isNaN(subtrahend)) return currentValue
+      return current - subtrahend
+    }
+
+    default:
+      return currentValue
+  }
+}

--- a/src/server/rule-engine/conditions.test.ts
+++ b/src/server/rule-engine/conditions.test.ts
@@ -1,0 +1,144 @@
+import { evaluateCondition } from './conditions'
+
+describe('evaluateCondition', () => {
+  describe('CONTAINS', () => {
+    test('matches case-insensitive substring', () => {
+      expect(evaluateCondition('Hello World', 'CONTAINS', 'world')).toBe(true)
+    })
+
+    test('returns false when substring not found', () => {
+      expect(evaluateCondition('Hello World', 'CONTAINS', 'xyz')).toBe(false)
+    })
+
+    test('handles null cell value', () => {
+      expect(evaluateCondition(null, 'CONTAINS', 'test')).toBe(false)
+    })
+  })
+
+  describe('NOT_CONTAINS', () => {
+    test('returns true when value not found', () => {
+      expect(evaluateCondition('Hello World', 'NOT_CONTAINS', 'xyz')).toBe(true)
+    })
+
+    test('returns false when value is found', () => {
+      expect(evaluateCondition('Hello World', 'NOT_CONTAINS', 'hello')).toBe(false)
+    })
+  })
+
+  describe('EQUALS', () => {
+    test('matches case-insensitive exact value', () => {
+      expect(evaluateCondition('Hello', 'EQUALS', 'hello')).toBe(true)
+    })
+
+    test('returns false for partial match', () => {
+      expect(evaluateCondition('Hello World', 'EQUALS', 'hello')).toBe(false)
+    })
+
+    test('handles numeric cell value', () => {
+      expect(evaluateCondition(42, 'EQUALS', '42')).toBe(true)
+    })
+  })
+
+  describe('REGEX', () => {
+    test('matches valid regex pattern', () => {
+      expect(evaluateCondition('abc-123', 'REGEX', '\\d+')).toBe(true)
+    })
+
+    test('returns false for non-matching pattern', () => {
+      expect(evaluateCondition('abc', 'REGEX', '^\\d+$')).toBe(false)
+    })
+
+    test('handles invalid regex gracefully', () => {
+      expect(evaluateCondition('test', 'REGEX', '[')).toBe(false)
+    })
+
+    test('is case-insensitive', () => {
+      expect(evaluateCondition('Hello', 'REGEX', '^hello$')).toBe(true)
+    })
+  })
+
+  describe('NOT_EMPTY', () => {
+    test('returns true for non-empty string', () => {
+      expect(evaluateCondition('hello', 'NOT_EMPTY')).toBe(true)
+    })
+
+    test('returns true for number', () => {
+      expect(evaluateCondition(42, 'NOT_EMPTY')).toBe(true)
+    })
+
+    test('returns true for zero', () => {
+      expect(evaluateCondition(0, 'NOT_EMPTY')).toBe(true)
+    })
+
+    test('returns false for null', () => {
+      expect(evaluateCondition(null, 'NOT_EMPTY')).toBe(false)
+    })
+
+    test('returns false for undefined', () => {
+      expect(evaluateCondition(undefined as never, 'NOT_EMPTY')).toBe(false)
+    })
+
+    test('returns false for empty string', () => {
+      expect(evaluateCondition('', 'NOT_EMPTY')).toBe(false)
+    })
+  })
+
+  describe('GREATER_THAN', () => {
+    test('numeric comparison works', () => {
+      expect(evaluateCondition(100, 'GREATER_THAN', '50')).toBe(true)
+    })
+
+    test('returns false when equal', () => {
+      expect(evaluateCondition(50, 'GREATER_THAN', '50')).toBe(false)
+    })
+
+    test('returns false when less', () => {
+      expect(evaluateCondition(10, 'GREATER_THAN', '50')).toBe(false)
+    })
+
+    test('returns false for non-numeric cell value', () => {
+      expect(evaluateCondition('abc', 'GREATER_THAN', '50')).toBe(false)
+    })
+
+    test('handles string numbers', () => {
+      expect(evaluateCondition('100', 'GREATER_THAN', '50')).toBe(true)
+    })
+
+    test('handles negative numbers', () => {
+      expect(evaluateCondition(-10, 'GREATER_THAN', '-20')).toBe(true)
+    })
+  })
+
+  describe('LESS_THAN', () => {
+    test('numeric comparison works', () => {
+      expect(evaluateCondition(10, 'LESS_THAN', '50')).toBe(true)
+    })
+
+    test('returns false when equal', () => {
+      expect(evaluateCondition(50, 'LESS_THAN', '50')).toBe(false)
+    })
+
+    test('returns false when greater', () => {
+      expect(evaluateCondition(100, 'LESS_THAN', '50')).toBe(false)
+    })
+
+    test('returns false for non-numeric condition value', () => {
+      expect(evaluateCondition(10, 'LESS_THAN', 'abc')).toBe(false)
+    })
+  })
+
+  describe('edge cases', () => {
+    test('handles Date cell value', () => {
+      const date = new Date('2024-01-15')
+      expect(evaluateCondition(date, 'CONTAINS', '2024')).toBe(true)
+    })
+
+    test('handles boolean cell value', () => {
+      expect(evaluateCondition(true, 'EQUALS', 'true')).toBe(true)
+    })
+
+    test('returns false for unknown condition', () => {
+      expect(evaluateCondition('test', 'UNKNOWN' as never, 'test')).toBe(false)
+    })
+  })
+})

--- a/src/server/rule-engine/conditions.ts
+++ b/src/server/rule-engine/conditions.ts
@@ -1,0 +1,58 @@
+import type { CellValue } from '../table/types'
+import type { RuleCondition } from './types'
+
+function toStringValue(cellValue: CellValue): string {
+  return cellValue instanceof Date
+    ? cellValue.toISOString()
+    : String(cellValue ?? '')
+}
+
+function compareNumeric(
+  cellValue: CellValue,
+  conditionValue: string | undefined,
+  comparator: (a: number, b: number) => boolean,
+): boolean {
+  const numCell = Number(cellValue)
+  const numCondition = Number(conditionValue)
+  if (Number.isNaN(numCell) || Number.isNaN(numCondition)) return false
+  return comparator(numCell, numCondition)
+}
+
+function matchesRegex(stringValue: string, pattern: string): boolean {
+  try {
+    return new RegExp(pattern, 'i').test(stringValue)
+  }
+  catch {
+    return false
+  }
+}
+
+type ConditionHandler = (stringValue: string, cellValue: CellValue, conditionValue?: string) => boolean
+
+const CONDITION_HANDLERS: Record<RuleCondition, ConditionHandler> = {
+  CONTAINS: (s, _c, v) => s.toLowerCase().includes(v!.toLowerCase()),
+  NOT_CONTAINS: (s, _c, v) => !s.toLowerCase().includes(v!.toLowerCase()),
+  EQUALS: (s, _c, v) => s.toLowerCase() === v!.toLowerCase(),
+  REGEX: (s, _c, v) => matchesRegex(s, v!),
+  NOT_EMPTY: (s, c) => c !== null && c !== undefined && s !== '',
+  GREATER_THAN: (_s, c, v) => compareNumeric(c, v, (a, b) => a > b),
+  LESS_THAN: (_s, c, v) => compareNumeric(c, v, (a, b) => a < b),
+}
+
+/**
+ * Evaluates a condition against a cell value.
+ *
+ * @param cellValue - The value from the table cell to evaluate
+ * @param condition - The condition type to check
+ * @param conditionValue - The value to compare against (not required for NOT_EMPTY)
+ * @returns Whether the condition is met
+ */
+export function evaluateCondition(
+  cellValue: CellValue,
+  condition: RuleCondition,
+  conditionValue?: string,
+): boolean {
+  const handler = CONDITION_HANDLERS[condition]
+  if (!handler) return false
+  return handler(toStringValue(cellValue), cellValue, conditionValue)
+}

--- a/src/server/rule-engine/index.ts
+++ b/src/server/rule-engine/index.ts
@@ -1,0 +1,7 @@
+export { loadImportRules, getRulesForBank, getRulesForPhase } from './rule-loader'
+export { processRules, createRawColumnResolver, createFireColumnResolver } from './rule-processor'
+export type {
+  ImportRule,
+  RowRuleResult,
+  RuleProcessingResult,
+} from './types'

--- a/src/server/rule-engine/rule-loader.test.ts
+++ b/src/server/rule-engine/rule-loader.test.ts
@@ -1,0 +1,348 @@
+import { SheetMock, SpreadsheetMock } from '../../../test-setup'
+import {
+  loadImportRules,
+  getRulesForBank,
+  getRulesForPhase,
+  clearRulesCache,
+} from './rule-loader'
+import type { ImportRule } from './types'
+
+vi.mock('../globals', () => ({
+  FireSpreadsheet: SpreadsheetMock,
+}))
+
+const getSheetByNameMock = vi.mocked(SpreadsheetMock.getSheetByName)
+const getLastRowMock = vi.mocked(SheetMock.getLastRow)
+
+function mockSheetData(rows: unknown[][]) {
+  getSheetByNameMock.mockReturnValue(SheetMock)
+  getLastRowMock.mockReturnValue(rows.length)
+  SheetMock.getSheetValues.mockReturnValue(rows as never)
+}
+
+const HEADER_ROW = [
+  'Rule Name', 'Bank(s)', 'Condition Column', 'Condition',
+  'Condition Value', 'Action', 'Action Column', 'Action Value',
+  'Stop Processing?', 'Rule Phase',
+]
+
+function makeRuleRow(overrides: Partial<Record<string, string | boolean>> = {}) {
+  return [
+    overrides['ruleName'] ?? 'Test Rule',
+    overrides['banks'] ?? 'All',
+    overrides['conditionColumn'] ?? 'description',
+    overrides['condition'] ?? 'CONTAINS',
+    overrides['conditionValue'] ?? 'internal',
+    overrides['action'] ?? 'EXCLUDE',
+    overrides['actionColumn'] ?? '',
+    overrides['actionValue'] ?? '',
+    overrides['stopProcessing'] ?? 'FALSE',
+    overrides['rulePhase'] ?? 'POST_TRANSFORM',
+  ]
+}
+
+describe('loadImportRules', () => {
+  beforeEach(() => {
+    clearRulesCache()
+    vi.clearAllMocks()
+  })
+
+  test('parses valid rules from sheet data', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow(),
+    ])
+
+    const { rules, warnings } = loadImportRules()
+
+    expect(rules).toHaveLength(1)
+    expect(warnings).toHaveLength(0)
+    expect(rules[0]).toEqual({
+      ruleName: 'Test Rule',
+      banks: ['all'],
+      conditionColumn: 'description',
+      condition: 'CONTAINS',
+      conditionValue: 'internal',
+      action: 'EXCLUDE',
+      actionColumn: 'description',
+      actionValue: undefined,
+      stopProcessing: false,
+      rulePhase: 'POST_TRANSFORM',
+      rowIndex: 2,
+    })
+  })
+
+  test('returns empty array when import-rules sheet does not exist', () => {
+    getSheetByNameMock.mockReturnValue(null as never)
+
+    const { rules, warnings } = loadImportRules()
+
+    expect(rules).toHaveLength(0)
+    expect(warnings).toHaveLength(0)
+  })
+
+  test('produces warning for rule with invalid condition', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ condition: 'INVALID' }),
+    ])
+
+    const { rules, warnings } = loadImportRules()
+
+    expect(rules).toHaveLength(0)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].message).toContain('Invalid condition')
+  })
+
+  test('produces warning for rule with missing condition column', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ conditionColumn: '' }),
+    ])
+
+    const { rules, warnings } = loadImportRules()
+
+    expect(rules).toHaveLength(0)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].message).toContain('Missing condition column')
+  })
+
+  test('produces warning for CONTAINS rule with no condition value', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ condition: 'CONTAINS', conditionValue: '' }),
+    ])
+
+    const { rules, warnings } = loadImportRules()
+
+    expect(rules).toHaveLength(0)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].message).toContain('requires a condition value')
+  })
+
+  test('allows NOT_EMPTY rule without condition value', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ condition: 'NOT_EMPTY', conditionValue: '' }),
+    ])
+
+    const { rules, warnings } = loadImportRules()
+
+    expect(rules).toHaveLength(1)
+    expect(warnings).toHaveLength(0)
+  })
+
+  test('produces warning for SET rule with no action value', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ action: 'SET', actionValue: '' }),
+    ])
+
+    const { rules, warnings } = loadImportRules()
+
+    expect(rules).toHaveLength(0)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].message).toContain('requires an action value')
+  })
+
+  test('produces warning for ADD rule with non-numeric action value', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ action: 'ADD', actionValue: 'abc' }),
+    ])
+
+    const { rules, warnings } = loadImportRules()
+
+    expect(rules).toHaveLength(0)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].message).toContain('requires a numeric action value')
+  })
+
+  test('produces warning for invalid rule phase', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ rulePhase: 'INVALID' }),
+    ])
+
+    const { rules, warnings } = loadImportRules()
+
+    expect(rules).toHaveLength(0)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].message).toContain('Invalid rule phase')
+  })
+
+  test('produces warning for missing banks', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ banks: '' }),
+    ])
+
+    const { rules, warnings } = loadImportRules()
+
+    expect(rules).toHaveLength(0)
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].message).toContain('Missing bank(s)')
+  })
+
+  test('skips blank rows (empty rule name)', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ ruleName: '' }),
+      makeRuleRow({ ruleName: 'Valid Rule' }),
+    ])
+
+    const { rules, warnings } = loadImportRules()
+
+    expect(rules).toHaveLength(1)
+    expect(rules[0].ruleName).toBe('Valid Rule')
+    expect(warnings).toHaveLength(0)
+  })
+
+  test('parses comma-separated banks correctly', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ banks: 'Bank A, Bank B, ING' }),
+    ])
+
+    const { rules } = loadImportRules()
+
+    expect(rules[0].banks).toEqual(['bank-a', 'bank-b', 'ing'])
+  })
+
+  test('defaults actionColumn to conditionColumn when empty', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ conditionColumn: 'description', actionColumn: '', action: 'SET', actionValue: 'test' }),
+    ])
+
+    const { rules } = loadImportRules()
+
+    expect(rules[0].actionColumn).toBe('description')
+  })
+
+  test('uses explicit actionColumn when provided', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ conditionColumn: 'description', actionColumn: 'category', action: 'SET', actionValue: 'Groceries' }),
+    ])
+
+    const { rules } = loadImportRules()
+
+    expect(rules[0].actionColumn).toBe('category')
+    expect(rules[0].conditionColumn).toBe('description')
+  })
+
+  test('parses stopProcessing as true', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ stopProcessing: 'TRUE' }),
+    ])
+
+    const { rules } = loadImportRules()
+
+    expect(rules[0].stopProcessing).toBe(true)
+  })
+
+  test('parses multiple rules in order', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ ruleName: 'Rule 1' }),
+      makeRuleRow({ ruleName: 'Rule 2' }),
+      makeRuleRow({ ruleName: 'Rule 3' }),
+    ])
+
+    const { rules } = loadImportRules()
+
+    expect(rules).toHaveLength(3)
+    expect(rules[0].rowIndex).toBe(2)
+    expect(rules[1].rowIndex).toBe(3)
+    expect(rules[2].rowIndex).toBe(4)
+  })
+
+  test('handles case-insensitive condition and action', () => {
+    mockSheetData([
+      HEADER_ROW,
+      makeRuleRow({ condition: 'contains', action: 'exclude', rulePhase: 'post_transform' }),
+    ])
+
+    const { rules } = loadImportRules()
+
+    expect(rules[0].condition).toBe('CONTAINS')
+    expect(rules[0].action).toBe('EXCLUDE')
+    expect(rules[0].rulePhase).toBe('POST_TRANSFORM')
+  })
+})
+
+describe('getRulesForBank', () => {
+  const rules: ImportRule[] = [
+    {
+      ruleName: 'All Banks', banks: ['all'], conditionColumn: 'description',
+      condition: 'CONTAINS', conditionValue: 'test', action: 'EXCLUDE',
+      stopProcessing: false, rulePhase: 'POST_TRANSFORM', rowIndex: 2,
+    },
+    {
+      ruleName: 'ING Only', banks: ['ing'], conditionColumn: 'description',
+      condition: 'CONTAINS', conditionValue: 'test', action: 'EXCLUDE',
+      stopProcessing: false, rulePhase: 'POST_TRANSFORM', rowIndex: 3,
+    },
+    {
+      ruleName: 'Multi Bank', banks: ['ing', 'revolut'], conditionColumn: 'description',
+      condition: 'CONTAINS', conditionValue: 'test', action: 'EXCLUDE',
+      stopProcessing: false, rulePhase: 'POST_TRANSFORM', rowIndex: 4,
+    },
+  ]
+
+  test('includes rules with "all" bank', () => {
+    const result = getRulesForBank(rules, 'ing')
+    expect(result).toContainEqual(expect.objectContaining({ ruleName: 'All Banks' }))
+  })
+
+  test('includes rules matching specific bank ID', () => {
+    const result = getRulesForBank(rules, 'ing')
+    expect(result).toContainEqual(expect.objectContaining({ ruleName: 'ING Only' }))
+  })
+
+  test('excludes rules for other banks', () => {
+    const result = getRulesForBank(rules, 'n26')
+    expect(result).toHaveLength(1)
+    expect(result[0].ruleName).toBe('All Banks')
+  })
+
+  test('handles case-insensitive bank matching via slugify', () => {
+    const result = getRulesForBank(rules, 'ING')
+    expect(result).toHaveLength(3)
+  })
+
+  test('matches multi-bank rules', () => {
+    const result = getRulesForBank(rules, 'revolut')
+    expect(result).toHaveLength(2)
+    expect(result).toContainEqual(expect.objectContaining({ ruleName: 'Multi Bank' }))
+  })
+})
+
+describe('getRulesForPhase', () => {
+  const rules: ImportRule[] = [
+    {
+      ruleName: 'Pre Rule', banks: ['all'], conditionColumn: 'Amount',
+      condition: 'GREATER_THAN', conditionValue: '100', action: 'EXCLUDE',
+      stopProcessing: false, rulePhase: 'PRE_TRANSFORM', rowIndex: 2,
+    },
+    {
+      ruleName: 'Post Rule', banks: ['all'], conditionColumn: 'description',
+      condition: 'CONTAINS', conditionValue: 'test', action: 'EXCLUDE',
+      stopProcessing: false, rulePhase: 'POST_TRANSFORM', rowIndex: 3,
+    },
+  ]
+
+  test('filters by PRE_TRANSFORM', () => {
+    const result = getRulesForPhase(rules, 'PRE_TRANSFORM')
+    expect(result).toHaveLength(1)
+    expect(result[0].ruleName).toBe('Pre Rule')
+  })
+
+  test('filters by POST_TRANSFORM', () => {
+    const result = getRulesForPhase(rules, 'POST_TRANSFORM')
+    expect(result).toHaveLength(1)
+    expect(result[0].ruleName).toBe('Post Rule')
+  })
+})

--- a/src/server/rule-engine/rule-loader.ts
+++ b/src/server/rule-engine/rule-loader.ts
@@ -1,0 +1,203 @@
+import { slugify } from '@/common/helpers'
+import { Logger } from '@/common/logger'
+import { FireSpreadsheet } from '../globals'
+import { Table } from '../table/Table'
+import type { CellValue } from '../table/types'
+import type {
+  ImportRule,
+  RuleAction,
+  RuleCondition,
+  RulePhase,
+  RuleWarning,
+} from './types'
+import {
+  ACTIONS_REQUIRING_VALUE,
+  CONDITIONS_REQUIRING_VALUE,
+  NUMERIC_ACTIONS,
+  VALID_ACTIONS,
+  VALID_CONDITIONS,
+  VALID_PHASES,
+} from './types'
+
+const IMPORT_RULES_SHEET_NAME = 'import-rules'
+const RULES_CACHE_KEY = 'cache.importRules'
+
+interface LoadResult {
+  rules: ImportRule[]
+  warnings: RuleWarning[]
+}
+
+let rulesCache: LoadResult | null = null
+
+function parseBoolean(value: CellValue): boolean {
+  return String(value ?? '').toLowerCase() === 'true'
+}
+
+function parseBanks(value: CellValue): string[] {
+  return String(value ?? '')
+    .split(',')
+    .map(b => slugify(b.trim()))
+    .filter(Boolean)
+}
+
+type PartialRule = Partial<ImportRule> & { ruleName: string, rowIndex: number }
+
+type ValidationCheck = (rule: PartialRule) => string | null
+
+const validationChecks: ValidationCheck[] = [
+  rule => !rule.conditionColumn ? 'Missing condition column' : null,
+  rule => (!rule.condition || !VALID_CONDITIONS.includes(rule.condition))
+    ? `Invalid condition: "${rule.condition ?? ''}"`
+    : null,
+  rule => (!rule.action || !VALID_ACTIONS.includes(rule.action))
+    ? `Invalid action: "${rule.action ?? ''}"`
+    : null,
+  rule => (!rule.rulePhase || !VALID_PHASES.includes(rule.rulePhase))
+    ? `Invalid rule phase: "${rule.rulePhase ?? ''}"`
+    : null,
+  rule => (rule.condition && CONDITIONS_REQUIRING_VALUE.includes(rule.condition) && !rule.conditionValue)
+    ? `Condition "${rule.condition}" requires a condition value`
+    : null,
+  rule => (rule.action && ACTIONS_REQUIRING_VALUE.includes(rule.action) && !rule.actionValue)
+    ? `Action "${rule.action}" requires an action value`
+    : null,
+  rule => (rule.action && NUMERIC_ACTIONS.includes(rule.action) && rule.actionValue && Number.isNaN(Number(rule.actionValue)))
+    ? `Action "${rule.action}" requires a numeric action value, got "${rule.actionValue}"`
+    : null,
+  rule => (!rule.banks || rule.banks.length === 0) ? 'Missing bank(s)' : null,
+]
+
+function validateRule(
+  rule: PartialRule,
+  warnings: RuleWarning[],
+): rule is ImportRule {
+  for (const check of validationChecks) {
+    const error = check(rule)
+    if (error) {
+      warnings.push({ ruleName: rule.ruleName, rowIndex: rule.rowIndex, message: error })
+      return false
+    }
+  }
+  return true
+}
+
+function parseRuleRow(row: CellValue[], rowIndex: number): Partial<ImportRule> & { ruleName: string, rowIndex: number } {
+  const conditionColumn = String(row[2] ?? '').trim()
+  const actionColumn = String(row[6] ?? '').trim()
+
+  return {
+    ruleName: String(row[0] ?? '').trim(),
+    banks: parseBanks(row[1]),
+    conditionColumn,
+    condition: String(row[3] ?? '').trim().toUpperCase() as RuleCondition,
+    conditionValue: String(row[4] ?? '').trim() || undefined,
+    action: String(row[5] ?? '').trim().toUpperCase() as RuleAction,
+    actionColumn: actionColumn || conditionColumn,
+    actionValue: String(row[7] ?? '').trim() || undefined,
+    stopProcessing: parseBoolean(row[8]),
+    rulePhase: String(row[9] ?? '').trim().toUpperCase() as RulePhase,
+    rowIndex,
+  }
+}
+
+function loadFromSheet(): LoadResult {
+  const sheet = FireSpreadsheet.getSheetByName(IMPORT_RULES_SHEET_NAME)
+
+  if (!sheet) {
+    Logger.log(`Sheet "${IMPORT_RULES_SHEET_NAME}" not found, no import rules loaded`)
+    return { rules: [], warnings: [] }
+  }
+
+  const rawValues = sheet.getSheetValues(1, 1, sheet.getLastRow(), -1) as CellValue[][]
+  const table = Table.from(rawValues)
+
+  // Shift header row
+  table.shiftRow()
+
+  const rules: ImportRule[] = []
+  const warnings: RuleWarning[] = []
+
+  for (let i = 0; i < table.getData().length; i++) {
+    const row = table.getData()[i]
+    const ruleName = String(row[0] ?? '').trim()
+
+    // Skip blank rows
+    if (!ruleName) continue
+
+    // rowIndex is i + 2: +1 for 0-indexing, +1 for the header row
+    const parsed = parseRuleRow(row, i + 2)
+
+    if (validateRule(parsed, warnings)) {
+      rules.push(parsed)
+    }
+  }
+
+  return { rules, warnings }
+}
+
+/**
+ * Loads import rules from the "import-rules" sheet.
+ * Uses in-memory and document cache (30s TTL) to avoid repeated reads.
+ */
+export function loadImportRules(): LoadResult {
+  if (rulesCache) {
+    return rulesCache
+  }
+
+  try {
+    const cache = CacheService.getDocumentCache()
+    const cached = cache.get(RULES_CACHE_KEY)
+
+    if (cached) {
+      try {
+        const parsed = JSON.parse(cached) as LoadResult
+        rulesCache = parsed
+        return parsed
+      }
+      catch {
+        Logger.warn('Failed to parse cached import rules')
+      }
+    }
+  }
+  catch {
+    // CacheService may not be available in all contexts
+  }
+
+  const result = loadFromSheet()
+
+  try {
+    const cache = CacheService.getDocumentCache()
+    cache.put(RULES_CACHE_KEY, JSON.stringify(result), 30)
+  }
+  catch {
+    // CacheService may not be available
+  }
+
+  rulesCache = result
+  return result
+}
+
+/**
+ * Filters rules to those applicable for a given bank account.
+ * Matches on "all" or slugified bank account ID.
+ */
+export function getRulesForBank(rules: ImportRule[], bankAccountId: string): ImportRule[] {
+  const slugifiedId = slugify(bankAccountId)
+  return rules.filter(rule =>
+    rule.banks.includes('all') || rule.banks.includes(slugifiedId),
+  )
+}
+
+/**
+ * Filters rules by their processing phase.
+ */
+export function getRulesForPhase(rules: ImportRule[], phase: RulePhase): ImportRule[] {
+  return rules.filter(rule => rule.rulePhase === phase)
+}
+
+/**
+ * Clears the in-memory rule cache. Used for testing.
+ */
+export function clearRulesCache(): void {
+  rulesCache = null
+}

--- a/src/server/rule-engine/rule-processor.test.ts
+++ b/src/server/rule-engine/rule-processor.test.ts
@@ -1,0 +1,444 @@
+import { Table } from '../table/Table'
+import type { ImportRule } from './types'
+import {
+  processRules,
+  createRawColumnResolver,
+  createFireColumnResolver,
+} from './rule-processor'
+
+function makeRule(overrides: Partial<ImportRule> = {}): ImportRule {
+  return {
+    ruleName: 'Test Rule',
+    banks: ['all'],
+    conditionColumn: 'description',
+    condition: 'CONTAINS',
+    conditionValue: 'internal',
+    action: 'EXCLUDE',
+    actionColumn: 'description',
+    actionValue: undefined,
+    stopProcessing: false,
+    rulePhase: 'POST_TRANSFORM',
+    rowIndex: 2,
+    ...overrides,
+  }
+}
+
+describe('createRawColumnResolver', () => {
+  test('resolves CSV header names to indices', () => {
+    const resolver = createRawColumnResolver(['Date', 'Amount', 'Description'])
+    expect(resolver('Amount')).toBe(1)
+    expect(resolver('Description')).toBe(2)
+  })
+
+  test('returns -1 for unknown column names', () => {
+    const resolver = createRawColumnResolver(['Date', 'Amount'])
+    expect(resolver('Missing')).toBe(-1)
+  })
+})
+
+describe('createFireColumnResolver', () => {
+  test('resolves FIRE column names to indices', () => {
+    const resolver = createFireColumnResolver()
+    expect(resolver('ref')).toBe(0)
+    expect(resolver('iban')).toBe(1)
+    expect(resolver('date')).toBe(2)
+    expect(resolver('amount')).toBe(3)
+    expect(resolver('description')).toBe(6)
+    expect(resolver('category')).toBe(9)
+  })
+
+  test('returns -1 for unknown column names', () => {
+    const resolver = createFireColumnResolver()
+    expect(resolver('nonexistent')).toBe(-1)
+  })
+})
+
+describe('processRules', () => {
+  describe('EXCLUDE action', () => {
+    test('marks matching row as excluded', () => {
+      const table = Table.from([
+        ['2024-01-01', 100, 'internal transfer'],
+        ['2024-01-02', 50, 'grocery store'],
+      ])
+      const resolver = createRawColumnResolver(['date', 'amount', 'description'])
+      const rules = [makeRule({ conditionColumn: 'description', conditionValue: 'internal' })]
+
+      const result = processRules(table, rules, resolver, false)
+
+      expect(result.rowResults[0].excluded).toBe(true)
+      expect(result.rowResults[0].excludedByRule).toBe('Test Rule')
+      expect(result.rowResults[1].excluded).toBe(false)
+      expect(result.rowsExcluded).toBe(1)
+    })
+
+    test('does not process further rules after EXCLUDE', () => {
+      const table = Table.from([
+        ['2024-01-01', 100, 'internal transfer'],
+      ])
+      const resolver = createRawColumnResolver(['date', 'amount', 'description'])
+      const rules = [
+        makeRule({ ruleName: 'Exclude Rule', action: 'EXCLUDE' }),
+        makeRule({ ruleName: 'Set Rule', action: 'SET', actionColumn: 'amount', actionValue: '999' }),
+      ]
+
+      const result = processRules(table, rules, resolver, false)
+
+      expect(result.rowResults[0].matchedRules).toHaveLength(1)
+      expect(result.rowResults[0].matchedRules[0].ruleName).toBe('Exclude Rule')
+    })
+  })
+
+  describe('SET action', () => {
+    test('modifies target column value', () => {
+      const table = Table.from([
+        ['cafe purchase', '', 50],
+      ])
+      const resolver = createRawColumnResolver(['description', 'category', 'amount'])
+      const rules = [makeRule({
+        conditionColumn: 'description',
+        condition: 'CONTAINS',
+        conditionValue: 'cafe',
+        action: 'SET',
+        actionColumn: 'category',
+        actionValue: 'Eating Out',
+      })]
+
+      const result = processRules(table, rules, resolver, false)
+
+      expect(table.getData()[0][1]).toBe('Eating Out')
+      expect(result.rowResults[0].modifications).toEqual({ category: 'Eating Out' })
+      expect(result.rowsModified).toBe(1)
+    })
+  })
+
+  describe('ADD action', () => {
+    test('adds to numeric column value', () => {
+      const table = Table.from([
+        ['purchase', 100],
+      ])
+      const resolver = createRawColumnResolver(['description', 'amount'])
+      const rules = [makeRule({
+        conditionColumn: 'description',
+        condition: 'NOT_EMPTY',
+        action: 'ADD',
+        actionColumn: 'amount',
+        actionValue: '10',
+      })]
+
+      const result = processRules(table, rules, resolver, false)
+
+      expect(table.getData()[0][1]).toBe(110)
+      expect(result.rowResults[0].modifications).toEqual({ amount: 110 })
+    })
+  })
+
+  describe('SUBTRACT action', () => {
+    test('subtracts from numeric column value', () => {
+      const table = Table.from([
+        ['purchase', 100],
+      ])
+      const resolver = createRawColumnResolver(['description', 'amount'])
+      const rules = [makeRule({
+        conditionColumn: 'description',
+        condition: 'NOT_EMPTY',
+        action: 'SUBTRACT',
+        actionColumn: 'amount',
+        actionValue: '25',
+      })]
+
+      const result = processRules(table, rules, resolver, false)
+
+      expect(table.getData()[0][1]).toBe(75)
+      expect(result.rowResults[0].modifications).toEqual({ amount: 75 })
+    })
+  })
+
+  describe('stopProcessing', () => {
+    test('prevents further rules for that row', () => {
+      const table = Table.from([
+        ['cafe', '', 50],
+      ])
+      const resolver = createRawColumnResolver(['description', 'category', 'amount'])
+      const rules = [
+        makeRule({
+          ruleName: 'Rule 1',
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'cafe',
+          action: 'SET',
+          actionColumn: 'category',
+          actionValue: 'Food',
+          stopProcessing: true,
+        }),
+        makeRule({
+          ruleName: 'Rule 2',
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'cafe',
+          action: 'SET',
+          actionColumn: 'category',
+          actionValue: 'Overwrite',
+        }),
+      ]
+
+      processRules(table, rules, resolver, false)
+
+      expect(table.getData()[0][1]).toBe('Food')
+    })
+
+    test('only affects the current row', () => {
+      const table = Table.from([
+        ['cafe', '', 50],
+        ['cafe', '', 30],
+      ])
+      const resolver = createRawColumnResolver(['description', 'category', 'amount'])
+      const rules = [
+        makeRule({
+          ruleName: 'Rule 1',
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'cafe',
+          action: 'SET',
+          actionColumn: 'category',
+          actionValue: 'Food',
+          stopProcessing: true,
+        }),
+        makeRule({
+          ruleName: 'Rule 2',
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'cafe',
+          action: 'SET',
+          actionColumn: 'category',
+          actionValue: 'Overwrite',
+        }),
+      ]
+
+      const result = processRules(table, rules, resolver, false)
+
+      // stopProcessing only stops for the row it matches, not subsequent rows
+      // BUT: Rule 1 with stopProcessing=true stops Rule 2 for EACH row individually
+      // Both rows should be 'Food' because each row processes Rule 1 first and stops
+      expect(table.getData()[0][1]).toBe('Food')
+      expect(table.getData()[1][1]).toBe('Food')
+      expect(result.rowResults[0].matchedRules).toHaveLength(1)
+      expect(result.rowResults[1].matchedRules).toHaveLength(1)
+    })
+  })
+
+  describe('rule ordering', () => {
+    test('rules are applied in the order provided', () => {
+      const table = Table.from([
+        ['cafe', '', 50],
+      ])
+      const resolver = createRawColumnResolver(['description', 'category', 'amount'])
+      const rules = [
+        makeRule({
+          ruleName: 'First',
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'cafe',
+          action: 'SET',
+          actionColumn: 'category',
+          actionValue: 'Food',
+        }),
+        makeRule({
+          ruleName: 'Second',
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'cafe',
+          action: 'SET',
+          actionColumn: 'category',
+          actionValue: 'Overwritten',
+        }),
+      ]
+
+      processRules(table, rules, resolver, false)
+
+      // Second rule overwrites first
+      expect(table.getData()[0][1]).toBe('Overwritten')
+    })
+  })
+
+  describe('dryRun mode', () => {
+    test('does not mutate table data', () => {
+      const table = Table.from([
+        ['cafe', '', 50],
+      ])
+      const resolver = createRawColumnResolver(['description', 'category', 'amount'])
+      const rules = [makeRule({
+        action: 'SET',
+        actionColumn: 'category',
+        actionValue: 'Food',
+        conditionColumn: 'description',
+        condition: 'CONTAINS',
+        conditionValue: 'cafe',
+      })]
+
+      processRules(table, rules, resolver, true)
+
+      expect(table.getData()[0][1]).toBe('')
+    })
+
+    test('tracks modifications in result', () => {
+      const table = Table.from([
+        ['cafe', '', 50],
+      ])
+      const resolver = createRawColumnResolver(['description', 'category', 'amount'])
+      const rules = [makeRule({
+        action: 'SET',
+        actionColumn: 'category',
+        actionValue: 'Food',
+        conditionColumn: 'description',
+        condition: 'CONTAINS',
+        conditionValue: 'cafe',
+      })]
+
+      const result = processRules(table, rules, resolver, true)
+
+      expect(result.rowResults[0].modifications).toEqual({ category: 'Food' })
+      expect(result.rowsModified).toBe(1)
+    })
+
+    test('tracks exclusions without mutating', () => {
+      const table = Table.from([
+        ['internal transfer', 100],
+      ])
+      const resolver = createRawColumnResolver(['description', 'amount'])
+      const rules = [makeRule()]
+
+      const result = processRules(table, rules, resolver, true)
+
+      expect(result.rowResults[0].excluded).toBe(true)
+      expect(result.rowsExcluded).toBe(1)
+      // Data is still in the table
+      expect(table.getData()).toHaveLength(1)
+    })
+  })
+
+  describe('unknown column handling', () => {
+    test('produces warning for unknown condition column', () => {
+      const table = Table.from([['test', 100]])
+      const resolver = createRawColumnResolver(['description', 'amount'])
+      const rules = [makeRule({ conditionColumn: 'nonexistent' })]
+
+      const result = processRules(table, rules, resolver, false)
+
+      expect(result.warnings).toHaveLength(1)
+      expect(result.warnings[0].message).toContain('Column "nonexistent" not found')
+    })
+
+    test('produces warning for unknown action column', () => {
+      const table = Table.from([['cafe', 100]])
+      const resolver = createRawColumnResolver(['description', 'amount'])
+      const rules = [makeRule({
+        conditionColumn: 'description',
+        condition: 'CONTAINS',
+        conditionValue: 'cafe',
+        action: 'SET',
+        actionColumn: 'nonexistent',
+        actionValue: 'test',
+      })]
+
+      const result = processRules(table, rules, resolver, false)
+
+      expect(result.warnings).toHaveLength(1)
+      expect(result.warnings[0].message).toContain('Action column "nonexistent" not found')
+    })
+  })
+
+  describe('multiple rules modifying different columns', () => {
+    test('multiple rules can modify different columns on same row', () => {
+      const table = Table.from([
+        ['cafe latte', '', '', 50],
+      ])
+      const resolver = createRawColumnResolver(['description', 'category', 'label', 'amount'])
+      const rules = [
+        makeRule({
+          ruleName: 'Categorize',
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'cafe',
+          action: 'SET',
+          actionColumn: 'category',
+          actionValue: 'Food',
+        }),
+        makeRule({
+          ruleName: 'Label',
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'cafe',
+          action: 'SET',
+          actionColumn: 'label',
+          actionValue: 'Coffee',
+        }),
+      ]
+
+      processRules(table, rules, resolver, false)
+
+      expect(table.getData()[0][1]).toBe('Food')
+      expect(table.getData()[0][2]).toBe('Coffee')
+    })
+  })
+
+  describe('rulesApplied count', () => {
+    test('counts unique rules that matched at least one row', () => {
+      const table = Table.from([
+        ['cafe', '', 50],
+        ['grocery', '', 30],
+        ['cafe', '', 20],
+      ])
+      const resolver = createRawColumnResolver(['description', 'category', 'amount'])
+      const rules = [
+        makeRule({
+          ruleName: 'Cafe Rule',
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'cafe',
+          action: 'SET',
+          actionColumn: 'category',
+          actionValue: 'Food',
+        }),
+        makeRule({
+          ruleName: 'Grocery Rule',
+          conditionColumn: 'description',
+          condition: 'CONTAINS',
+          conditionValue: 'grocery',
+          action: 'SET',
+          actionColumn: 'category',
+          actionValue: 'Groceries',
+        }),
+      ]
+
+      const result = processRules(table, rules, resolver, false)
+
+      // Both rules matched at least one row
+      expect(result.rulesApplied).toBe(2)
+      expect(result.rulesLoaded).toBe(2)
+    })
+  })
+
+  describe('with FireTable column resolver', () => {
+    test('resolves FIRE column names correctly', () => {
+      // Build a minimal FireTable-like data structure (16 columns aligned to FIRE_COLUMNS)
+      // [ref, iban, date, amount, balance, contra_account, description, comments, icon, category, label, import_date, hours, disabled, contra_iban, currency]
+      const table = Table.from([
+        [null, 'NL123', new Date('2024-01-01'), 50, null, 'Coffee Shop', 'latte purchase', null, null, '', null, new Date(), null, null, null, 'EUR'],
+      ])
+      const resolver = createFireColumnResolver()
+      const rules = [makeRule({
+        conditionColumn: 'contra_account',
+        condition: 'CONTAINS',
+        conditionValue: 'Coffee',
+        action: 'SET',
+        actionColumn: 'category',
+        actionValue: 'Eating Out',
+      })]
+
+      processRules(table, rules, resolver, false)
+
+      // category is at index 9
+      expect(table.getData()[0][9]).toBe('Eating Out')
+    })
+  })
+})

--- a/src/server/rule-engine/rule-processor.ts
+++ b/src/server/rule-engine/rule-processor.ts
@@ -1,0 +1,144 @@
+import { FIRE_COLUMNS } from '@/common/constants'
+import type { Table } from '../table/Table'
+import type { ImportRule, RowRuleResult, RuleProcessingResult, RuleWarning } from './types'
+import { evaluateCondition } from './conditions'
+import { applyAction } from './actions'
+
+type ColumnResolver = (columnName: string) => number
+
+/**
+ * Creates a column resolver for raw CSV headers.
+ * Matches column names exactly (case-sensitive, as they come from the CSV header).
+ */
+export function createRawColumnResolver(headers: string[]): ColumnResolver {
+  return (columnName: string) => headers.indexOf(columnName)
+}
+
+/**
+ * Creates a column resolver for FIRE column names.
+ * Matches case-insensitively against the standard FIRE_COLUMNS.
+ */
+export function createFireColumnResolver(): ColumnResolver {
+  return (columnName: string) => {
+    const lower = columnName.toLowerCase()
+    return FIRE_COLUMNS.findIndex(col => col === lower)
+  }
+}
+
+function createEmptyRowResult(): RowRuleResult {
+  return {
+    excluded: false,
+    matchedRules: [],
+    modifications: {},
+  }
+}
+
+/**
+ * Applies import rules to each row of a table, evaluating conditions
+ * and executing actions.
+ *
+ * @param table - The table to process (Table for PRE_TRANSFORM, FireTable for POST_TRANSFORM)
+ * @param rules - The rules to apply, in priority order (by rowIndex)
+ * @param resolveColumn - Function to resolve column names to 0-based indices
+ * @param dryRun - If true, track results without mutating the table
+ * @returns Processing result with per-row outcomes and summary counts
+ */
+export function processRules(
+  table: Table,
+  rules: ImportRule[],
+  resolveColumn: ColumnResolver,
+  dryRun: boolean,
+): RuleProcessingResult {
+  const data = table.getData()
+  const rowResults: RowRuleResult[] = []
+  const warnings: RuleWarning[] = []
+  const appliedRuleNames = new Set<string>()
+  let rowsExcluded = 0
+  let rowsModified = 0
+
+  for (const row of data) {
+    const rowResult = createEmptyRowResult()
+    let wasModified = false
+
+    for (const rule of rules) {
+      const conditionColIndex = resolveColumn(rule.conditionColumn)
+      if (conditionColIndex === -1) {
+        warnings.push({
+          ruleName: rule.ruleName,
+          rowIndex: rule.rowIndex,
+          message: `Column "${rule.conditionColumn}" not found`,
+        })
+        continue
+      }
+
+      const cellValue = row[conditionColIndex]
+
+      if (!evaluateCondition(cellValue, rule.condition, rule.conditionValue)) {
+        continue
+      }
+
+      // Condition matched
+      appliedRuleNames.add(rule.ruleName)
+
+      if (rule.action === 'EXCLUDE') {
+        rowResult.excluded = true
+        rowResult.excludedByRule = rule.ruleName
+        rowResult.matchedRules.push({
+          ruleName: rule.ruleName,
+          action: rule.action,
+        })
+        break
+      }
+
+      const actionColumn = rule.actionColumn ?? rule.conditionColumn
+      const actionColIndex = resolveColumn(actionColumn)
+      if (actionColIndex === -1) {
+        warnings.push({
+          ruleName: rule.ruleName,
+          rowIndex: rule.rowIndex,
+          message: `Action column "${actionColumn}" not found`,
+        })
+        continue
+      }
+
+      const currentValue = row[actionColIndex]
+      const newValue = applyAction(currentValue, rule.action, rule.actionValue)
+
+      rowResult.matchedRules.push({
+        ruleName: rule.ruleName,
+        action: rule.action,
+        actionColumn,
+        actionValue: rule.actionValue,
+      })
+      rowResult.modifications[actionColumn] = newValue
+
+      if (!dryRun) {
+        row[actionColIndex] = newValue
+      }
+
+      wasModified = true
+
+      if (rule.stopProcessing) {
+        break
+      }
+    }
+
+    if (rowResult.excluded) {
+      rowsExcluded++
+    }
+    else if (wasModified) {
+      rowsModified++
+    }
+
+    rowResults.push(rowResult)
+  }
+
+  return {
+    rowResults,
+    rulesLoaded: rules.length,
+    rulesApplied: appliedRuleNames.size,
+    rowsExcluded,
+    rowsModified,
+    warnings,
+  }
+}

--- a/src/server/rule-engine/types.ts
+++ b/src/server/rule-engine/types.ts
@@ -1,0 +1,90 @@
+import type { CellValue } from '../table/types'
+
+export type RuleCondition
+  = 'REGEX'
+    | 'CONTAINS'
+    | 'EQUALS'
+    | 'NOT_EMPTY'
+    | 'NOT_CONTAINS'
+    | 'GREATER_THAN'
+    | 'LESS_THAN'
+
+export type RuleAction
+  = 'EXCLUDE'
+    | 'SET'
+    | 'SUBTRACT'
+    | 'ADD'
+
+export type RulePhase
+  = 'PRE_TRANSFORM'
+    | 'POST_TRANSFORM'
+
+export interface ImportRule {
+  ruleName: string
+  banks: string[]
+  conditionColumn: string
+  condition: RuleCondition
+  conditionValue?: string
+  action: RuleAction
+  actionColumn?: string
+  actionValue?: string
+  stopProcessing: boolean
+  rulePhase: RulePhase
+  rowIndex: number
+}
+
+export interface RuleWarning {
+  ruleName: string
+  rowIndex: number
+  message: string
+}
+
+export interface RuleMatch {
+  ruleName: string
+  action: RuleAction
+  actionColumn?: string
+  actionValue?: string
+}
+
+export interface RowRuleResult {
+  excluded: boolean
+  excludedByRule?: string
+  matchedRules: RuleMatch[]
+  modifications: Record<string, CellValue>
+}
+
+export interface RuleProcessingResult {
+  rowResults: RowRuleResult[]
+  rulesLoaded: number
+  rulesApplied: number
+  rowsExcluded: number
+  rowsModified: number
+  warnings: RuleWarning[]
+}
+
+export const VALID_CONDITIONS: readonly RuleCondition[] = [
+  'REGEX', 'CONTAINS', 'EQUALS', 'NOT_EMPTY', 'NOT_CONTAINS', 'GREATER_THAN', 'LESS_THAN',
+] as const
+
+export const VALID_ACTIONS: readonly RuleAction[] = [
+  'EXCLUDE', 'SET', 'SUBTRACT', 'ADD',
+] as const
+
+export const VALID_PHASES: readonly RulePhase[] = [
+  'PRE_TRANSFORM', 'POST_TRANSFORM',
+] as const
+
+/** Conditions that require a conditionValue to be provided. */
+export const CONDITIONS_REQUIRING_VALUE: readonly RuleCondition[] = [
+  'REGEX', 'CONTAINS', 'EQUALS', 'NOT_CONTAINS', 'GREATER_THAN', 'LESS_THAN',
+] as const
+
+/** Actions that require an actionValue to be provided. */
+export const ACTIONS_REQUIRING_VALUE: readonly RuleAction[] = [
+  'SET', 'ADD', 'SUBTRACT',
+] as const
+
+/** Actions that require a numeric actionValue. */
+export const NUMERIC_ACTIONS: readonly RuleAction[] = [
+  'ADD', 'SUBTRACT',
+] as const


### PR DESCRIPTION
Implement a rule engine that reads user-defined rules from an "import-rules" Google Sheet tab and applies them during the import pipeline. Rules support conditions (CONTAINS, EQUALS, REGEX, NOT_EMPTY, NOT_CONTAINS, GREATER_THAN, LESS_THAN) and actions (EXCLUDE, SET, ADD, SUBTRACT) across two phases: PRE_TRANSFORM (raw CSV columns) and POST_TRANSFORM (FIRE columns).

The preview pipeline runs rules in dry-run mode to show excluded rows (red) with tooltips, rule warnings in an accordion, and applied rule counts. The import pipeline applies rules for real, filtering excluded rows and mutating values before writing to the sheet. The import dialog no longer auto-closes, showing a summary with a manual Close button instead.

Generate by `claude-opus-4-6` using the `claude-code` CLI tool

```shell
Context Usage
  Claude Opus 4.6
  154.5k/200k tokens (77%)
  Estimated usage by category
  System prompt: 6.6k tokens (3.3%)
  System tools: 11.2k tokens (5.6%) 
  Memory files: 2.7k tokens (1.3%)
  Skills: 453 tokens (0.2%)
  Messages: 133.3k tokens (66.7%)
  Free space: 12.8k (6.4%)
  Autocompact buffer: 33k tokens (16.5%)

Total cost:               $11.41
  Total duration (API):   21m 7s
  Total duration (wall):  4h 3m 39s
  Total code changes:     2475 lines added, 172 lines removed
  Usage by model:
    Opus 4.6:   17.4k input, 63.3k output, 11.9m cache read, 521.6k cache write ($10.90)
    Haiku 4.5:  22.3k input, 22.4k output, 1.9m cache read, 143.9k cache write ($0.50)
```
