### PR TITLE
🧪 [testing improvement] Add unit tests for getAccountIdentifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.15.1-beta
+
+- **Testing** - Added missing unit tests for `getAccountIdentifiers` in `src/server/accounts/account-utils.ts`, covering multiple accounts, special characters, and edge cases like empty data or rows.
+
 ## 4.15.0-beta
 
 - **Feature** - Introduces a rule-based data processing pipeline that allows users to define transaction import rules in a Google Sheet. The implementation includes a new rule engine module that handles parsing and applying rules during the pre-transform and post-transform phases of the import process, along with UI enhancements to display rule application summaries and warnings.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-fire",
-  "version": "4.15.0-beta",
+  "version": "4.15.1-beta",
   "author": "Melle Dijkstra",
   "description": "Google App Script utilities to automate the FIRE google sheet",
   "license": "MIT",

--- a/src/server/accounts/account-utils.test.ts
+++ b/src/server/accounts/account-utils.test.ts
@@ -83,6 +83,54 @@ describe('Utility tests', () => {
     // So it should be called only once.
     expect(getRangeByNameSpy).toHaveBeenCalledTimes(1)
   })
+
+  describe('getAccountIdentifiers', () => {
+    test('should return slugified identifiers for multiple accounts', () => {
+      RangeMock.getValues.mockReturnValueOnce([
+        ['Deutsche Bank', 'DB123456789', '100'],
+        ['n26', 'BANK123456789', '200'],
+        ['Banco de España', 'BANK124463534', '300'],
+      ])
+
+      expect(AccountUtils.getAccountIdentifiers()).toStrictEqual([
+        'deutsche-bank',
+        'n26',
+        'banco-de-espaa',
+      ])
+    })
+
+    test('should handle special characters and spaces in account names', () => {
+      RangeMock.getValues.mockReturnValueOnce([
+        ['My Bank Account!', 'IBAN123', '100'],
+        ['  Spaces  Around  ', 'IBAN456', '200'],
+      ])
+
+      expect(AccountUtils.getAccountIdentifiers()).toStrictEqual([
+        'my-bank-account',
+        'spaces-around',
+      ])
+    })
+
+    test('should return an empty array when no account data is present', () => {
+      RangeMock.getValues.mockReturnValueOnce([])
+
+      expect(AccountUtils.getAccountIdentifiers()).toStrictEqual([])
+    })
+
+    test('should ignore empty rows and rows without IBAN', () => {
+      RangeMock.getValues.mockReturnValueOnce([
+        ['N26', 'IBAN1', '100'],
+        ['', '', ''],
+        ['No IBAN', '', '50'],
+        ['Revolut', 'IBAN2', '200'],
+      ])
+
+      expect(AccountUtils.getAccountIdentifiers()).toStrictEqual([
+        'n26',
+        'revolut',
+      ])
+    })
+  })
 })
 
 describe('calculateNewBalance', () => {


### PR DESCRIPTION
🎯 **What:** The testing gap for `AccountUtils.getAccountIdentifiers` has been addressed.
📊 **Coverage:** The following scenarios are now tested:
- Multiple standard account names (correct slugification).
- Account names with special characters, spaces, and casing (verified robust slugification).
- Empty account data (returns empty array).
- Edge cases like empty rows or rows missing IBANs (verified filtering logic).
✨ **Result:** Improved reliability and test coverage for the account utility module, ensuring that account identifiers are correctly derived and filtered from spreadsheet data.

---
*PR created automatically by Jules for task [2675338732646320059](https://jules.google.com/task/2675338732646320059) started by @melledijkstra*