### PR TITLE
🔒 Fix Insecure Deserialization of Cached Accounts Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.15.7-beta
+
+- **Security** - 🔒 Fixed Insecure Deserialization of Cached Accounts Data by validating the parsed object's shape before returning it from `fetchAccountsData`.
+
 ## 4.15.6-beta
 
 - Separate CI and CD pipelines

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-fire",
-  "version": "4.15.6-beta",
+  "version": "4.15.7-beta",
   "author": "Melle Dijkstra",
   "description": "Google App Script utilities to automate the FIRE google sheet",
   "license": "MIT",

--- a/src/server/accounts/account-utils.security.test.ts
+++ b/src/server/accounts/account-utils.security.test.ts
@@ -1,0 +1,37 @@
+import { CacheServiceMock, RangeMock } from '../../../test-setup'
+import { AccountUtils } from './account-utils'
+
+describe('AccountUtils Security Tests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    AccountUtils.resetStaticCache()
+  })
+
+  test('should fall back to live retrieval if cached data is malformed', () => {
+    const cacheGetMock = vi.fn()
+    CacheServiceMock.getDocumentCache.mockReturnValue({
+      get: cacheGetMock,
+      put: vi.fn(),
+    } as unknown as GoogleAppsScript.Cache.Cache)
+
+    // Mock cache to return data with missing required fields
+    cacheGetMock.mockReturnValue(JSON.stringify({
+      'malicious-account': {
+        notLabel: 'Not a label',
+        notIban: 'Not an IBAN',
+      },
+    }))
+
+    // Mock live retrieval to return valid data
+    RangeMock.getValues.mockReturnValueOnce([
+      ['N26', 'DB123456789', '302.80'],
+    ])
+
+    const accounts = AccountUtils.getBankAccounts()
+
+    // If it used the malicious cache, it would have 'malicious-account'
+    // If it fell back to live retrieval, it should have 'n26'
+    expect(accounts).toHaveProperty('n26')
+    expect(accounts).not.toHaveProperty('malicious-account')
+  })
+})

--- a/src/server/accounts/account-utils.ts
+++ b/src/server/accounts/account-utils.ts
@@ -25,7 +25,7 @@ function isAccountInfo(value: unknown): value is AccountInfo {
 }
 
 function isAccountInfoRecord(value: unknown): value is Record<string, AccountInfo> {
-  if (typeof value !== 'object' || value === null) return false
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
   return Object.values(value).every(isAccountInfo)
 }
 

--- a/src/server/accounts/account-utils.ts
+++ b/src/server/accounts/account-utils.ts
@@ -15,7 +15,7 @@ interface AccountInfo {
 }
 
 function isAccountInfo(value: unknown): value is AccountInfo {
-  if (typeof value !== 'object' || value === null) return false
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
   const info = value as Record<string, unknown>
   return (
     typeof info.label === 'string'

--- a/src/server/accounts/account-utils.ts
+++ b/src/server/accounts/account-utils.ts
@@ -14,6 +14,21 @@ interface AccountInfo {
   balance: number | null
 }
 
+function isAccountInfo(value: unknown): value is AccountInfo {
+  if (typeof value !== 'object' || value === null) return false
+  const info = value as Record<string, unknown>
+  return (
+    typeof info.label === 'string'
+    && typeof info.iban === 'string'
+    && (info.balance === null || typeof info.balance === 'number')
+  )
+}
+
+function isAccountInfoRecord(value: unknown): value is Record<string, AccountInfo> {
+  if (typeof value !== 'object' || value === null) return false
+  return Object.values(value).every(isAccountInfo)
+}
+
 export const isNumeric = (value: unknown): boolean => {
   if (typeof value === 'number') return Number.isFinite(value)
   if (typeof value === 'string' && value.trim() !== '') {
@@ -34,8 +49,11 @@ export class AccountUtils {
     const cachedData = cache?.get(BANK_ACCOUNTS_CACHE_KEY)
     if (cachedData) {
       try {
-        this.cachedAccountsData = JSON.parse(cachedData)
-        return this.cachedAccountsData!
+        const parsed = JSON.parse(cachedData)
+        if (isAccountInfoRecord(parsed)) {
+          this.cachedAccountsData = parsed
+          return this.cachedAccountsData
+        }
       }
       catch {
         // Fall back to live retrieval if parsing fails


### PR DESCRIPTION
🎯 **What:** Fixed an insecure deserialization vulnerability in `AccountUtils.fetchAccountsData` by validating the shape of the cached data after `JSON.parse`.
⚠️ **Risk:** Untrusted data from the `CacheService` was being assigned directly to `cachedAccountsData` and used without verification, which could lead to type-related runtime errors or unexpected behavior if the cache was poisoned.
🛡️ **Solution:** Implemented `isAccountInfo` and `isAccountInfoRecord` type guards to validate the structure of the parsed object. The system now falls back to live data retrieval if the validation fails. Added a security test case to verify the fix.

---
*PR created automatically by Jules for task [1094445817741909995](https://jules.google.com/task/1094445817741909995) started by @melledijkstra*