### PR TITLE
🧹 [code health improvement: remove unused export formatCellValue]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 4.15.8-beta
+
+- **Refactor** - 🧹 Removed unused export `formatCellValue` from `src/server/import-pipeline/pipeline.ts` to improve maintainability and resolve Knip issue.
+
 ## 4.15.7-beta
 
 - **Security** - 🔒 Fixed Insecure Deserialization of Cached Accounts Data by validating the parsed object's shape before returning it from `fetchAccountsData`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gas-fire",
-  "version": "4.15.7-beta",
+  "version": "4.15.8-beta",
   "author": "Melle Dijkstra",
   "description": "Google App Script utilities to automate the FIRE google sheet",
   "license": "MIT",

--- a/src/server/import-pipeline/pipeline.ts
+++ b/src/server/import-pipeline/pipeline.ts
@@ -2,7 +2,7 @@ import { getRowHash } from '@/common/helpers'
 import { Logger } from '@/common/logger'
 import { FireTable } from '@/common/table/FireTable'
 import { Table } from '@/common/table/Table'
-import type { CellValue, TransactionAction, UserDecisions } from '@/common/types'
+import type { TransactionAction, UserDecisions } from '@/common/types'
 import { Config } from '../config'
 import type { RuleEngineResult } from '../rule-engine/types'
 import { FireSheet } from '../spreadsheet/FireSheet'
@@ -119,23 +119,6 @@ export function duplicateDetectionStage(input: FireTable, context: PreviewPipeli
   }
 
   return input
-}
-
-/**
- * Formats a single cell value to a display string.
- * Dates are formatted as 'yyyy-MM-dd' using the spreadsheet's timezone.
- */
-export function formatCellValue(cell: CellValue): string {
-  if (cell instanceof Date) {
-    try {
-      const timeZone = FireSheet.getTimeZone()
-      return Utilities.formatDate(cell, timeZone, 'yyyy-MM-dd')
-    }
-    catch {
-      return cell.toISOString().split('T')[0]
-    }
-  }
-  return String(cell ?? '')
 }
 
 /**


### PR DESCRIPTION
🎯 **What:**
- Removed the unused `formatCellValue` function from `src/server/import-pipeline/pipeline.ts`.
- Removed the unused `CellValue` type import from the same file.
- Incremented the project version in `package.json` to `4.15.8-beta`.
- Updated `CHANGELOG.md` to reflect the changes.

💡 **Why:**
- Resolves a Knip warning about an unused export.
- Reduces dead code in the repository.
- Keeps the import statements clean by removing unused types.

✅ **Verification:**
- Ran `pnpm knip` and confirmed `formatCellValue` is no longer reported as an unused export.
- Ran `pnpm test run` and all 152 tests passed.
- Ran `pnpm lint` and confirmed no linting errors.

✨ **Result:**
- Cleaner codebase with less dead code.
- Resolved Knip issue for better code health.

---
*PR created automatically by Jules for task [14321488266338858819](https://jules.google.com/task/14321488266338858819) started by @melledijkstra*