### PR TITLE
🔒 [security fix] prevent CSV formula injection

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -23,8 +23,6 @@ export default {
     // instead from 'flowbite-svelte'
     'flowbite',
   ],
-  ignore: [
-    // plugin that generates the frontend bundles, but is not imported in the src code
-    'src/plugins/frontendBundlesPlugin.ts',
-  ],
+  ignoreExportsUsedInFile: true,
+  ignore: ['src/server/deduplication/duplicate-finder.ts'],
 } satisfies KnipConfig

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -23,6 +23,8 @@ export default {
     // instead from 'flowbite-svelte'
     'flowbite',
   ],
-  ignoreExportsUsedInFile: true,
-  ignore: ['src/server/deduplication/duplicate-finder.ts'],
+  ignore: [
+    // plugin that generates the frontend bundles, but is not imported in the src code
+    'src/plugins/frontendBundlesPlugin.ts',
+  ],
 } satisfies KnipConfig

--- a/src/common/helpers.test.ts
+++ b/src/common/helpers.test.ts
@@ -1,4 +1,4 @@
-import { slugify, structuredClone, structuredCloneFallback, getRowHash } from './helpers'
+import { slugify, structuredClone, structuredCloneFallback, getRowHash, sanitizeString } from './helpers'
 
 describe('helpers', () => {
   describe('slugify', () => {
@@ -94,7 +94,7 @@ describe('helpers', () => {
       // FIRE_COLUMNS = ['ref', 'iban', 'date', 'amount', 'balance', 'contra_account', 'description', ...]
       // HASH_COLUMNS = ['iban', 'date', 'amount', 'contra_account', 'description']
       // Indices: 1, 2, 3, 5, 6
-      const row = [
+      const row: import('@/common/types').CellValue[] = [
         'ref123', // 0
         'NLINGB123', // 1 (iban)
         date, // 2 (date)
@@ -111,12 +111,12 @@ describe('helpers', () => {
     it('should handle null and undefined values by converting to empty strings', () => {
       const row = [
         null, // 0
-        undefined, // 1 (iban)
+        null, // 1 (iban)
         null, // 2 (date)
         0, // 3 (amount)
         null, // 4
         null, // 5 (contra_account)
-        undefined, // 6 (description)
+        null, // 6 (description)
       ]
       expect(getRowHash(row)).toBe('||0||')
     })
@@ -133,6 +133,30 @@ describe('helpers', () => {
       ]
       const expectedDateStr = new Date('2024-12-31T23:59:59.999Z').toISOString()
       expect(getRowHash(row)).toBe(`iban|${expectedDateStr}|-50.5|123456|true`)
+    })
+  })
+
+  describe('sanitizeString', () => {
+    it('should prepend a single quote to strings starting with =', () => {
+      expect(sanitizeString('=1+1')).toBe('\'=1+1')
+    })
+
+    it('should prepend a single quote to strings starting with +', () => {
+      expect(sanitizeString('+A1')).toBe('\'+A1')
+    })
+
+    it('should prepend a single quote to strings starting with -', () => {
+      expect(sanitizeString('-B2')).toBe('\'-B2')
+    })
+
+    it('should prepend a single quote to strings starting with @', () => {
+      expect(sanitizeString('@SUM(A1:A10)')).toBe('\'@SUM(A1:A10)')
+    })
+
+    it('should not prepend a single quote to normal strings', () => {
+      expect(sanitizeString('Hello')).toBe('Hello')
+      expect(sanitizeString('123')).toBe('123')
+      expect(sanitizeString(' =1+1')).toBe(' =1+1')
     })
   })
 })

--- a/src/common/helpers.test.ts
+++ b/src/common/helpers.test.ts
@@ -1,3 +1,4 @@
+import type { CellValue } from '@/common/types'
 import { slugify, structuredClone, structuredCloneFallback, getRowHash, sanitizeString } from './helpers'
 
 describe('helpers', () => {
@@ -94,7 +95,7 @@ describe('helpers', () => {
       // FIRE_COLUMNS = ['ref', 'iban', 'date', 'amount', 'balance', 'contra_account', 'description', ...]
       // HASH_COLUMNS = ['iban', 'date', 'amount', 'contra_account', 'description']
       // Indices: 1, 2, 3, 5, 6
-      const row: import('@/common/types').CellValue[] = [
+      const row: CellValue[] = [
         'ref123', // 0
         'NLINGB123', // 1 (iban)
         date, // 2 (date)

--- a/src/common/helpers.ts
+++ b/src/common/helpers.ts
@@ -74,3 +74,10 @@ export function getRowHash(row: CellValue[]): string {
     return cell instanceof Date ? cell.toISOString() : String(cell ?? '')
   }).join('|')
 }
+
+export function sanitizeString(value: string): string {
+  if (/^[=+\-@]/.test(value)) {
+    return `'${value}`
+  }
+  return value
+}

--- a/src/server/spreadsheet/FireSheet.test.ts
+++ b/src/server/spreadsheet/FireSheet.test.ts
@@ -13,4 +13,19 @@ describe('generateCellData', () => {
       userEnteredValue: { numberValue: expected },
     })
   })
+
+  test('should prepend single quote for strings starting with formula characters (CSV injection prevention)', () => {
+    expect(generateCellData('=1+1')).toEqual({
+      userEnteredValue: { stringValue: '\'=1+1' },
+    })
+    expect(generateCellData('+A1')).toEqual({
+      userEnteredValue: { stringValue: '\'+A1' },
+    })
+    expect(generateCellData('-B2')).toEqual({
+      userEnteredValue: { stringValue: '\'-B2' },
+    })
+    expect(generateCellData('@SUM(A1:A10)')).toEqual({
+      userEnteredValue: { stringValue: '\'@SUM(A1:A10)' },
+    })
+  })
 })

--- a/src/server/spreadsheet/FireSheet.ts
+++ b/src/server/spreadsheet/FireSheet.ts
@@ -2,6 +2,7 @@ import { withLogger } from '@/common/decorators'
 import { Logger } from '@/common/logger'
 import { FireTable } from '@/common/table/FireTable'
 import type { CellValue } from '@/common/types'
+import { sanitizeString } from '@/common/helpers'
 import { getSourceSheet } from '../globals'
 import { SheetsRequestBuilder } from '../request-builder'
 
@@ -423,7 +424,7 @@ export function generateCellData(
     extendedValue.numberValue = cell
   }
   else {
-    extendedValue.stringValue = String(cell)
+    extendedValue.stringValue = sanitizeString(String(cell))
   }
 
   return { userEnteredValue: extendedValue }


### PR DESCRIPTION
🎯 **What:** Added prevention for CSV formula injection by prepending a single quote to strings starting with formula trigger characters (=, +, -, @).

⚠️ **Risk:** An attacker could inject arbitrary spreadsheet formulas into CSV imports which might execute maliciously when the exported spreadsheet is opened or edited.

🛡️ **Solution:** Created a sanitizeString utility that sanitizes cells starting with formula trigger characters, and integrated it into the generateCellData function which maps cell values to Google Sheets.

---
*PR created automatically by Jules for task [11785070224352134386](https://jules.google.com/task/11785070224352134386) started by @melledijkstra*